### PR TITLE
fix base address for go mem allocation

### DIFF
--- a/cli/assets/templates/go/target.json
+++ b/cli/assets/templates/go/target.json
@@ -1,10 +1,13 @@
 {
-    "inherits": [ "wasm" ],
+    "inherits": [
+        "wasm"
+    ],
     "ldflags": [
         "--import-memory",
         "--initial-memory=65536",
         "--max-memory=65536",
         "-zstack-size=6560",
-        "--strip-all"
+        "--strip-all",
+        "--global-base=6560"
     ]
 }


### PR DESCRIPTION
Initial memory gets used by new memory allocations in Go, overwriting framebuffer and keys. This linker setting will match the Rust hello world and has stopped the corruption in my framebuffer.