### PR TITLE
png2src --rust should conform to rust style guide

### DIFF
--- a/cli/lib/png2src.js
+++ b/cli/lib/png2src.js
@@ -114,10 +114,13 @@ function run (sourceFile, lang) {
         break;
 
     case "rust":
-        console.log(`const ${varName.toLocaleUpperCase()}_WIDTH = ${png.width};`);
-        console.log(`const ${varName.toLocaleUpperCase()}_HEIGHT = ${png.height};`);
-        console.log(`const ${varName.toLocaleUpperCase()}_FLAGS = ${flags}; // ${flagsHumanReadable}`);
-        process.stdout.write(`const ${varName.toLocaleUpperCase()}: [u8; ${bytes.length}] = [ `);
+        let idiomaticVarName = (varName.substr(0,1) + varName.substr(1)
+                        .replace(/[A-Z]/g, l => '_' + l))
+                        .toLocaleUpperCase()
+        console.log(`const ${idiomaticVarName}_WIDTH = ${png.width};`);
+        console.log(`const ${idiomaticVarName}_HEIGHT = ${png.height};`);
+        console.log(`const ${idiomaticVarName}_FLAGS = ${flags}; // ${flagsHumanReadable}`);
+        process.stdout.write(`const ${idiomaticVarName}: [u8; ${bytes.length}] = [ `);
         printBytes();
         console.log(" ];");
         break;

--- a/cli/lib/png2src.js
+++ b/cli/lib/png2src.js
@@ -114,10 +114,10 @@ function run (sourceFile, lang) {
         break;
 
     case "rust":
-        console.log(`const ${varName}Width: u32 = ${png.width};`);
-        console.log(`const ${varName}Height: u32 = ${png.height};`);
-        console.log(`const ${varName}Flags: u32 = ${flags}; // ${flagsHumanReadable}`);
-        process.stdout.write(`const ${varName}: [u8; ${bytes.length}] = [ `);
+        console.log(`const ${varName.toLocaleUpperCase()}_WIDTH = ${png.width};`);
+        console.log(`const ${varName.toLocaleUpperCase()}_HEIGHT = ${png.height};`);
+        console.log(`const ${varName.toLocaleUpperCase()}_FLAGS = ${flags}; // ${flagsHumanReadable}`);
+        process.stdout.write(`const ${varName.toLocaleUpperCase()}: [u8; ${bytes.length}] = [ `);
         printBytes();
         console.log(" ];");
         break;


### PR DESCRIPTION
This PR adjusts the code generate by `png2src --rust` to conform to the idiom that `static` and `const` variable name should have a [SCREAMING_SNAKE_CASE](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html?highlight=SCREAMING_SNAKE_CASE#accessing-or-modifying-a-mutable-static-variable). Current output when running `cargo check` with the generated code produces the following warnings.

```
Checking cart v0.1.0 (/home/rfm/projects/a-bit-rowdy)
warning: constant `png_name_width` should have an upper case name
 --> src/sprites.rs:1:11
  |
1 | pub const png_name_width: u32 = 48;
  |           ^^^^^^^^^^^^^^ help: convert the identifier to upper case: `PNG_NAME_WIDTH`
  |
  = note: `#[warn(non_upper_case_globals)]` on by default

warning: constant `png_name_height` should have an upper case name
 --> src/sprites.rs:2:11
  |
2 | pub const png_name_height: u32 = 80;
  |           ^^^^^^^^^^^^^^^ help: convert the identifier to upper case: `PNG_NAME_HEIGHT`

warning: constant `png_name_flags` should have an upper case name
 --> src/sprites.rs:3:11
  |
3 | pub const png_name_flags: u32 = 1; // BLIT_2BPP
  |           ^^^^^^^^^^^^^^ help: convert the identifier to upper case: `PNG_NAME_FLAGS`

warning: constant `png_name` should have an upper case name
 --> src/sprites.rs:4:11
  |
4 | pub const png_name: [u8; 960] = [
  |           ^^^^^^^^ help: convert the identifier to upper case: `PNG_NAME`

warning: 4 warnings emitted

    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
```

This PR also adds conversion from camel or upper camel case into screaming snake case.