### PR TITLE
[git]: prevent accidental commits of `cli/node_modules` or `runtimes/web/node_modules`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+node_modules
+
+# Misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+.pnpm-debug.log*

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,8 +1,6 @@
 /static/embed
 /static/download
 
-# Dependencies
-/node_modules
 
 # Production
 /build
@@ -10,14 +8,3 @@
 # Generated files
 .docusaurus
 .cache-loader
-
-# Misc
-.DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
-
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*


### PR DESCRIPTION
### Description

Moves .gitignore declaration of `node_modules`  and oher commonly ignored files from `site/node_modules` to `<repo-root>/.gitignore`

### Why

`node_modules` are commonly ignored via a  `.gitignore` set at the repository root directory.
It prevents accidental commits of node_modules and simplify the development of PRs.
