### PR TITLE
[png2src] Improvements, support custom templates

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -34,6 +34,7 @@ program.command("png2src <images...>")
     .option("--c", "Generate C/C++ source")
     .option("--rs, --rust", "Generate Rust source")
     .option("--go", "Generate Go source")
+    .option("--t, --template <file>", "Generate source follow template", "")
     .action((images, opts) => {
         const png2src = require("./lib/png2src");
         png2src.runAll(images, opts);

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -34,7 +34,7 @@ program.command("png2src <images...>")
     .option("--c", "Generate C/C++ source")
     .option("--rs, --rust", "Generate Rust source")
     .option("--go", "Generate Go source")
-    .option("--t, --template <file>", "Generate source follow template", "")
+    .option("--t, --template <file>", "Template file with a custom output format")
     .action((images, opts) => {
         const png2src = require("./lib/png2src");
         png2src.runAll(images, opts);

--- a/cli/lib/png2src.js
+++ b/cli/lib/png2src.js
@@ -22,7 +22,7 @@ const char %name%[%length%] = { %bytes% };
 `const %idiomaticName%_WIDTH = %width%;
 const %idiomaticName%_HEIGHT = %height%;
 const %idiomaticName%_FLAGS = %flags%; // %flagsHumanReadable%
-const %idiomaticName%:[u8;%length%] = [ %bytes% ];
+const %idiomaticName%: [u8; %length%] = [ %bytes% ];
 `,  
 
     go: 

--- a/site/docs/guides/sprites.md
+++ b/site/docs/guides/sprites.md
@@ -180,7 +180,7 @@ const char %name%[%length%] = { %bytes% };
 Where:
 - `%name%` - filename (string),
 - `%idiomaticName%` - Rust specific variable name (string)
-- `%width%`, `%height%` - image dimensions (intiger)
+- `%width%`, `%height%` - image dimensions (integer)
 - `%flags%`, `%flagsHumanReadable%` - type flag as integer and enum name (BLIT_2BPP or BLIT_1BPP)
-- `%length%` - count of bytes (intiger)
+- `%length%` - count of bytes (integer)
 - `%bytes%` - comma separated series of bytes (string)

--- a/site/docs/guides/sprites.md
+++ b/site/docs/guides/sprites.md
@@ -163,3 +163,24 @@ blit(bunny, 10, 10, bunny_width, bunny_height, bunny_flags);
 [`DRAW_COLORS`](basic-drawing) is used here to modify the 4 colors of the original sprite. Reading
 from right to left: color 1 becomes 3, color 2 becomes 1, color 3 becomes 0 (transparent), and color
 4 becomes 2.
+
+### Custom template
+
+You can use a custom template for generating a image source.
+Use a `--template filename` for this.
+
+Basic template (C):
+```
+#define %name%Width %width%
+#define %name%Height %height%
+#define %name%Flags %flagsHumanReadable%
+const char %name%[%length%] = { %bytes% };
+```
+
+Where:
+- `%name%` - filename (string),
+- `%idiomaticName%` - Rust specific variable name (string)
+- `%width%`, `%height%` - image dimensions (intiger)
+- `%flags%`, `%flagsHumanReadable%` - type flag as integer and enum name (BLIT_2BPP or BLIT_1BPP)
+- `%length%` - count of bytes (intiger)
+- `%bytes%` - comma separated series of bytes (string)


### PR DESCRIPTION
Png2src is good, but code had a hardcoded switch-bassed generators for specific language.

I reformat code to string-tempates, now very easy add another source generators.

Other feature - custom templates, you can generate a game-specific source, for example:

```
export const %name% = {
	width: %width%,
	height: %height%,
	flags: %flags%,
	data: memory.data<u8>([ %bytes% ])
};
```

This template will emit a object export for AssemblyScript instead of constants, simmilar Trait/Object/Struct can be generated and for Rust/Go/C.

Guide for custom template is added also.

PS:
i use a template for AS like this:
```
import { Frame } from "../nodes/sprite";

const %name% = memory.data<u8>([ %bytes% ]);
export const %name%Frame = new Frame(%width%, %height%, %name%, %flags%);
```
