### PR TITLE
Fixed small error in png2src

### DIFF
--- a/cli/lib/png2src.js
+++ b/cli/lib/png2src.js
@@ -132,7 +132,7 @@ function run (sourceFile, template) {
         .replace(/%name%/gi, varName)
         .replace(/%idiomaticName%/gi, idiomaticVarName)
         .replace(/%height%/gi, png.height)
-        .replace(/%width%/gi, png.height)
+        .replace(/%width%/gi, png.width)
         .replace(/%length%/gi, bytes.length)
         .replace(/%flags%/gi, flags)
         .replace(/%flagsHumanReadable%/gi, flagsHumanReadable)


### PR DESCRIPTION
In templates, "width" got replaced by "height" instead of the width.