### PR TITLE
[POC]: fix(rust): allocation not working

### DIFF
--- a/cli/assets/templates/rust/.cargo/config.toml
+++ b/cli/assets/templates/rust/.cargo/config.toml
@@ -8,7 +8,7 @@ rustflags = [
     # Import memory from WASM-4
     "-C", "link-arg=--import-memory",
     "-C", "link-arg=--initial-memory=65536",
-    "-C", "link-arg=--max-memory=65536",
+    "-C", "link-arg=--max-memory=131072",
 
     # Reserve 1024 bytes of stack space, offset from 6580
     "-C", "link-arg=-zstack-size=7584",

--- a/runtimes/web/src/framebuffer.js
+++ b/runtimes/web/src/framebuffer.js
@@ -5,6 +5,10 @@ const FONT = new Uint8Array([ 0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xc7,0xc7,
 
 export class Framebuffer {
     constructor (memory) {
+        this.updateMemory(memory);
+    }
+
+    updateMemory(memory) {
         this.bytes = new Uint8Array(memory, constants.ADDR_FRAMEBUFFER, WIDTH*HEIGHT >> 2);
         this.drawColors = new Uint16Array(memory, constants.ADDR_DRAW_COLORS, 1);
     }

--- a/runtimes/web/src/runtime.js
+++ b/runtimes/web/src/runtime.js
@@ -21,7 +21,7 @@ export class Runtime {
 
         this.apu = new APU();
 
-        this.memory = new WebAssembly.Memory({initial: 1, maximum: 1});
+        this.memory = new WebAssembly.Memory({initial: 1, maximum: 2});
         this.data = new DataView(this.memory.buffer);
 
         this.framebuffer = new Framebuffer(this.memory.buffer);
@@ -282,6 +282,8 @@ export class Runtime {
         this.framebuffer.clear();
         if (this.wasm.exports.update != null) {
             this.wasm.exports.update();
+            this.data = new DataView(this.memory.buffer);
+            this.framebuffer.updateMemory(this.memory.buffer);
         }
 
         this.composite();


### PR DESCRIPTION
A poc for a fix to the allocation errors in rust.

### Description

The main issue regarding allocation is tied to the fact that carts
can have at most [a single memory page](https://github.com/aduros/wasm4/blob/main/runtimes/web/src/runtime.js#L24) while heap allocation is implemented by requesting `memory.grow` and its memory is placed after the initial one.

> This is all unfortunately working as intended, however, due to the way that the current wasm target works. The heap is fundamentally allocated via memory.grow instructions and can't be preallocated with the wasm32-unknown-unknown target's default allocator. Put another way, the default allocator provided by wasm32-unknown-unknown will unconditionally consider the current memory at startup as part of the wasm's own image (rodata, bss, static data, etc), so the only way it can get memory for it to manage is to call memory.grow.

source: https://github.com/rustwasm/wasm-bindgen/issues/1389#issuecomment-476224477

### wee_alloc

Current fix uses the default allocator but switching to [wee_alloc](https://github.com/rustwasm/wee_alloc) without increasing the max page size would not fix the issue:

> Reading through the code it appears that what wee_alloc does is make the assumption that what ever memory we start with is off-limits completely, and instead will use the grow_memory instruction to create the first piece of memory needed for the heap. That effectively means that the index/address of the start of the heap is highest index of what ever the initial size is, plus one.

source: https://github.com/rustwasm/wee_alloc/issues/61

I've tried to use wee_alloc with and without no_std before writing this PR; it always throws oom errors.

---

### Regarding the POC

These changes allowed me to create new rust project and use and mutate Hashmap, Vec and String instances inside `update`. 
I've not tested these changes in other languages nor I've not tried to use wee_alloc as global allocator.
Moreover I currently have no idea regarding the optimal maximum page size.

### Why are you updating this.data & this.framebuffer?

```js
  //  runtimes/web/src/runtime.js 
   this.data = new DataView(this.memory.buffer);
   this.framebuffer.updateMemory(this.memory.buffer);
 ```

This change is necessary to avoid 2 exceptions  that are thrown  by
- `<dataview-instance>.setUint<size>()`
- `<framebuffer>.clear()`

---

### Issues

fixes #37 #36 #30

related issues #39 #42 

### References

- https://github.com/rustwasm/wasm-bindgen/issues/1389#issuecomment-476224477
- https://frehberg.wordpress.com/webassembly-and-dynamic-memory/
- https://github.com/rustwasm/wee_alloc/issues/61
- https://github.com/rustwasm/wee_alloc/blob/master/wee_alloc/src/imp_wasm32.rs
