### PR TITLE
fix: reduce framerate onto 60 FPS

### DIFF
--- a/runtimes/web/src/index.js
+++ b/runtimes/web/src/index.js
@@ -342,9 +342,24 @@ async function loadCartWasm () {
     window.addEventListener("pointermove", onPointerEvent);
     window.addEventListener("pointerup", onPointerEvent);
 
+    // https://gist.github.com/addyosmani/5434533#file-limitloop-js-L60
+
+    const INTERVAL = 1000 / 60;
+
+    // lastFrame is not a real time, it has frame-gap correction
+    let lastFrame = performance.now();
+
     function loop () {
-        runtime.update();
         requestAnimationFrame(loop);
+
+        const now = performance.now();
+        const deltaFrame = now - lastFrame;
+
+        if (deltaFrame >= INTERVAL) {
+            lastFrame = now - (deltaFrame % INTERVAL);
+            runtime.update();
+        }
+
     }
     loop();
 })();


### PR DESCRIPTION
Realted: #24, #73

Use a implementation from:

https://gist.github.com/addyosmani/5434533#file-limitloop-js-L60

how to check?

Run chrome without v-sync:
https://gist.github.com/brunosimon/c15e7451a802fa8e34c0678620022f7d

Open any game.

Video:  https://youtu.be/VxCclCHjwII
LEFT- fixed, RIGHT - current
