### PR TITLE
refactor(png2src): change rust template dimensions from u32 to usize

### DIFF
--- a/cli/lib/png2src.js
+++ b/cli/lib/png2src.js
@@ -19,9 +19,9 @@ const uint8_t %name%[%length%] = { %bytes% };
 `,
 
     rust: 
-`const %idiomaticName%_WIDTH: u32 = %width%;
-const %idiomaticName%_HEIGHT: u32 = %height%;
-const %idiomaticName%_FLAGS: u32 = %flags%; // %flagsHumanReadable%
+`const %idiomaticName%_WIDTH: usize = %width%;
+const %idiomaticName%_HEIGHT: usize = %height%;
+const %idiomaticName%_FLAGS: usize = %flags%; // %flagsHumanReadable%
 const %idiomaticName%: [u8; %length%] = [ %bytes% ];
 `,  
 


### PR DESCRIPTION
Description

`usize` is used to index vectors, arrays, strings and slices.
It is system dependent either 32bit or 64bit.

References:

* https://doc.rust-lang.org/std/primitive.usize.html