### PR TITLE
Setting default language using env vars

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -6,10 +6,16 @@ const { supportedIconExtensions } = require('./lib/utils/icon');
 
 program.command("new <directory>")
     .description("Create a new blank project")
-    .option("--as, --assemblyscript", "Create AssemblyScript project")
-    .option("--c", "Create C/C++ project")
-    .option("--rs, --rust", "Create Rust project")
-    .option("--go", "Create Go project")
+    .option("--as, --assemblyscript", "Create AssemblyScript project (Shorthand for --lang as/--lang assemblyscript)")
+    .option("--c", "Create C/C++ project (Shorthand for --lang c)")
+    .option("--rs, --rust", "Create Rust project (Shorthand for --lang rs/--lang rust)")
+    .option("--go", "Create Go project (Shorthand for --lang go)")
+    .addOption(
+        new Option("--lang <lang>", "Use the given language")
+        .env("W4_LANG")
+        .choices(["as", "assemblyscript", "c", "go", "rs", "rust"])
+        .default("as")
+    )
     .action(async (dir, opts) => {
         const newCmd = require("./lib/new");
         newCmd.run(dir, opts);
@@ -41,11 +47,17 @@ program.command("run <cart>")
 
 program.command("png2src <images...>")
     .description("Convert images to source code")
-    .option("--as, --assemblyscript", "Generate AssemblyScript source")
-    .option("--c", "Generate C/C++ source")
-    .option("--rs, --rust", "Generate Rust source")
-    .option("--go", "Generate Go source")
+    .option("--as, --assemblyscript", "Generate AssemblyScript source (Shorthand for --lang as/--lang assemblyscript)")
+    .option("--c", "Generate C/C++ source (Shorthand for --lang c)")
+    .option("--rs, --rust", "Generate Rust source (Shorthand for --lang rs/--lang rust)")
+    .option("--go", "Generate Go source (Shorthand for --lang go)")
     .option("--t, --template <file>", "Template file with a custom output format")
+    .addOption(
+        new Option("--lang <lang>", "Use the given language")
+        .env("W4_LANG")
+        .choices(["as", "assemblyscript", "c", "go", "rs", "rust"])
+        .default("as")
+    )
     .action((images, opts) => {
         const png2src = require("./lib/png2src");
         png2src.runAll(images, opts);

--- a/cli/lib/new.js
+++ b/cli/lib/new.js
@@ -3,30 +3,32 @@ const path = require("path");
 const fs = require("fs");
 
 const LANGS = {
-    C: "c",
-    ASSEMBLYSCRIPT: "assemblyscript",
-    RUST: "rust",
-    GO: "go",
+    c: "c",
+    as: "assemblyscript",
+    assemblyscript: "assemblyscript",
+    rs: "rust",
+    rust: "rust",
+    go: "go",
 }
 
 const HELP = {
-    [LANGS.C]: {
+    c: {
         name: "C",
         build: "make",
         cart: "build/cart.wasm",
     },
-    [LANGS.ASSEMBLYSCRIPT]: {
+    assemblyscript: {
         name: "AssemblyScript",
         setup: "npm install",
         build: "npm run build",
         cart: "build/cart.wasm",
     },
-    [LANGS.RUST]: {
+    rust: {
         name: "Rust",
         build: "cargo build --release",
         cart: "target/wasm32-unknown-unknown/release/cart.wasm",
     },
-    [LANGS.GO]: {
+    go: {
         name: "Go",
         build: "make",
         cart: "build/cart.wasm",
@@ -34,17 +36,15 @@ const HELP = {
 }
 
 async function run (destDir, opts) {
-    let lang;
+    let lang = LANGS[opts.lang];
     if (opts.assemblyscript) {
-        lang = LANGS.ASSEMBLYSCRIPT;
+        lang = LANGS.assemblyscript;
     } else if (opts.c) {
-        lang = LANGS.C;
+        lang = LANGS.c;
     } else if (opts.rust) {
-        lang = LANGS.RUST;
+        lang = LANGS.rust;
     } else if (opts.go) {
-        lang = LANGS.GO;
-    } else {
-        lang = LANGS.ASSEMBLYSCRIPT;
+        lang = LANGS.go;
     }
 
     const srcDir = path.resolve(__dirname+"/../assets/templates/"+lang);
@@ -72,7 +72,7 @@ async function run (destDir, opts) {
 
 async function init (destDir, lang) {
     switch (lang) {
-        case LANGS.ASSEMBLYSCRIPT:
+        case LANGS.assemblyscript:
             const projectName = path.basename(destDir);
             const file = destDir + "/package.json";
             const json = JSON.parse(fs.readFileSync(file));

--- a/cli/lib/png2src.js
+++ b/cli/lib/png2src.js
@@ -2,6 +2,14 @@ const fs = require("fs");
 const path = require("path");
 const pngjs = require("pngjs");
 
+const LANGS={
+    as: "assemblyscript",
+    assemblyscript: "assemblyscript",
+    c: "c",
+    rs: "rust",
+    rust: "rust",
+    go: "go"
+}
 const DEFAULT_LANG = 'assemblyscript';
 const TEMPLATES = {        
     assemblyscript: 
@@ -144,7 +152,7 @@ function run (sourceFile, template) {
 exports.run = run;
 
 function runAll (files, opts) {
-    let template = TEMPLATES[DEFAULT_LANG];
+    let template = TEMPLATES[LANGS[opts.lang]];
 
     if (!opts.template) {
         // iterate over all options and search a key that presented in templates


### PR DESCRIPTION
Setting the env var "W4_LANG" changes the default value for "new" and "png2src".
For this, a new option was added: "--lang".
This option can only have these options:

- as
- assemblyscript
- c
- rs
- rust
- go

In case no value was provided by either env or cli,
it falls back to "as".
It can still be overriden by using the options --as etc.

Examples:
```bash
w4 new snake # Creates "snake" using AssemblyScript
w4 new --go snake # Creates "snake" using Go
W4_LANG=go w4 new snake # Creates "snake" using Go
W4_LANG=go w4 new --rust snake # Creates snake using Rust
```

The same is true for `png2src`.