### PR TITLE
Added "w4 init" - Fixes #50

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -4,29 +4,45 @@ const { program, Option } = require("commander");
 const pkg = require('./package.json');
 const { supportedIconExtensions } = require('./lib/utils/icon');
 
-program.command("new <directory>")
-    .description("Create a new blank project")
-    .option("--as, --assemblyscript", "Create AssemblyScript project (Shorthand for --lang as/--lang assemblyscript)")
-    .option("--c", "Create C/C++ project (Shorthand for --lang c)")
-    .option("--rs, --rust", "Create Rust project (Shorthand for --lang rs/--lang rust)")
-    .option("--go", "Create Go project (Shorthand for --lang go)")
-    .addOption(
-        new Option("--lang <lang>", "Use the given language")
-        .env("W4_LANG")
-        .choices(["as", "assemblyscript", "c", "go", "rs", "rust"])
-        .default("as")
-    )
+let blankProject = (cmd) =>
+    cmd
+        .option("--as, --assemblyscript", "Create AssemblyScript project (Shorthand for --lang as/--lang assemblyscript)")
+        .option("--c", "Create C/C++ project (Shorthand for --lang c)")
+        .option("--rs, --rust", "Create Rust project (Shorthand for --lang rs/--lang rust)")
+        .option("--go", "Create Go project (Shorthand for --lang go)")
+        .addOption(
+            new Option("--lang <lang>", "Use the given language")
+                .env("W4_LANG")
+                .choices(["as", "assemblyscript", "c", "go", "rs", "rust"])
+                .default("as")
+        )
+
+
+blankProject(
+    program.command("new <directory>")
+        .alias("create")
+        .description("Create a new blank project")
+)
     .action(async (dir, opts) => {
         const newCmd = require("./lib/new");
         newCmd.run(dir, opts);
+    });
+
+blankProject(
+    program.command("init")
+        .description("Create a new blank project in current folder")
+)
+    .action(async (opts) => {
+        const newCmd = require("./lib/new");
+        newCmd.run(".", opts);
     });
 
 program.command("watch")
     .description("Rebuild and refresh when source code changes")
     .addOption(
         new Option("-n, --no-open", "Doesn't open the browser")
-        .env("W4_NO_OPEN")
-        .default(false)
+            .env("W4_NO_OPEN")
+            .default(false)
     )
     .action(opts => {
         const watch = require("./lib/watch");
@@ -37,8 +53,8 @@ program.command("run <cart>")
     .description("Open a cartridge in the emulator")
     .addOption(
         new Option("-n, --no-open", "Doesn't open the browser")
-        .env("W4_NO_OPEN")
-        .default(false)
+            .env("W4_NO_OPEN")
+            .default(false)
     )
     .action((cart, opts) => {
         const server = require("./lib/server");
@@ -54,9 +70,9 @@ program.command("png2src <images...>")
     .option("--t, --template <file>", "Template file with a custom output format")
     .addOption(
         new Option("--lang <lang>", "Use the given language")
-        .env("W4_LANG")
-        .choices(["as", "assemblyscript", "c", "go", "rs", "rust"])
-        .default("as")
+            .env("W4_LANG")
+            .choices(["as", "assemblyscript", "c", "go", "rs", "rust"])
+            .default("as")
     )
     .action((images, opts) => {
         const png2src = require("./lib/png2src");
@@ -88,6 +104,6 @@ program
 // @see https://nodejs.org/api/process.html#process_event_unhandledrejection
 process.on('unhandledRejection', unhandledRejectionError => {
     console.log('[w4] error:\n');
-    
+
     throw unhandledRejectionError;
 });


### PR DESCRIPTION
In essence a "w4 init" is an alias to "w4 new ."

To achieve this and reduce code duplication, I've created a new
function called "blankProject" inside cli.js.
It takes a program.command and attaches the options of the "new" command
This function then is called for "new" and "init".

To make it a bit simpler still, I've also added a "real" alias to
"new" called "create".

Further "changes"to the source code are due to auto-formatting it.

// Edit: Yay, another low-hanging fruit solved!