### PR TITLE
feat(framebuffer): add hline and vline functions

### DIFF
--- a/cli/assets/templates/assemblyscript/src/wasm4.ts
+++ b/cli/assets/templates/assemblyscript/src/wasm4.ts
@@ -66,7 +66,7 @@ export declare function line (x1: i32, y1: i32, x2: i32, y2: i32): void;
 @external("env", "hline")
 export declare function hline (x: i32, y: i32, len: i32): void;
 
-/** Draws a horizontal line. */
+/** Draws a vertical line. */
 // @ts-ignore: decorator
 @external("env", "vline")
 export declare function vline (x: i32, y: i32, len: i32): void;

--- a/cli/assets/templates/assemblyscript/src/wasm4.ts
+++ b/cli/assets/templates/assemblyscript/src/wasm4.ts
@@ -61,6 +61,16 @@ export const BLIT_ROTATE: u32 = 8;
 @external("env", "line")
 export declare function line (x1: i32, y1: i32, x2: i32, y2: i32): void;
 
+/** Draws a horizontal line. */
+// @ts-ignore: decorator
+@external("env", "hline")
+export declare function hline (x: i32, y: i32, len: i32): void;
+
+/** Draws a horizontal line. */
+// @ts-ignore: decorator
+@external("env", "vline")
+export declare function vline (x: i32, y: i32, len: i32): void;
+
 /** Draws an oval (or circle). */
 // @ts-ignore: decorator
 @external("env", "oval")

--- a/cli/assets/templates/assemblyscript/src/wasm4.ts
+++ b/cli/assets/templates/assemblyscript/src/wasm4.ts
@@ -64,12 +64,12 @@ export declare function line (x1: i32, y1: i32, x2: i32, y2: i32): void;
 /** Draws a horizontal line. */
 // @ts-ignore: decorator
 @external("env", "hline")
-export declare function hline (x: i32, y: i32, len: i32): void;
+export declare function hline (x: i32, y: i32, len: u32): void;
 
 /** Draws a vertical line. */
 // @ts-ignore: decorator
 @external("env", "vline")
-export declare function vline (x: i32, y: i32, len: i32): void;
+export declare function vline (x: i32, y: i32, len: u32): void;
 
 /** Draws an oval (or circle). */
 // @ts-ignore: decorator

--- a/cli/assets/templates/c/src/wasm4.h
+++ b/cli/assets/templates/c/src/wasm4.h
@@ -70,6 +70,14 @@ void blitSub (const uint8_t* data, int32_t x, int32_t y, uint32_t width, uint32_
 WASM_IMPORT("line")
 void line (int32_t x, int32_t y, uint32_t width, uint32_t height);
 
+/** Draws a horizontal line. */
+WASM_IMPORT("hline")
+void hline (int32_t x, int32_t y, int32_t len);
+
+/** Draws a horizontal line. */
+WASM_IMPORT("vline")
+void vline (int32_t x, int32_t y, int32_t len);
+
 /** Draws an oval (or circle). */
 WASM_IMPORT("oval")
 void oval (int32_t x, int32_t y, uint32_t width, uint32_t height);

--- a/cli/assets/templates/c/src/wasm4.h
+++ b/cli/assets/templates/c/src/wasm4.h
@@ -74,7 +74,7 @@ void line (int32_t x, int32_t y, uint32_t width, uint32_t height);
 WASM_IMPORT("hline")
 void hline (int32_t x, int32_t y, int32_t len);
 
-/** Draws a horizontal line. */
+/** Draws a vertical line. */
 WASM_IMPORT("vline")
 void vline (int32_t x, int32_t y, int32_t len);
 

--- a/cli/assets/templates/c/src/wasm4.h
+++ b/cli/assets/templates/c/src/wasm4.h
@@ -72,11 +72,11 @@ void line (int32_t x, int32_t y, uint32_t width, uint32_t height);
 
 /** Draws a horizontal line. */
 WASM_IMPORT("hline")
-void hline (int32_t x, int32_t y, int32_t len);
+void hline (int32_t x, int32_t y, uint32_t len);
 
 /** Draws a vertical line. */
 WASM_IMPORT("vline")
-void vline (int32_t x, int32_t y, int32_t len);
+void vline (int32_t x, int32_t y, uint32_t len);
 
 /** Draws an oval (or circle). */
 WASM_IMPORT("oval")

--- a/cli/assets/templates/go/w4/wasm4.go
+++ b/cli/assets/templates/go/w4/wasm4.go
@@ -62,6 +62,14 @@ const BLIT_ROTATE = 8
 //go:export line
 func Line(x1 int, y1 int, x2 int, y2 int)
 
+/** Draws a horizontal line. */
+//go:export hline
+func HLine(x int, y int, len int)
+
+/** Draws a vertical line. */
+//go:export vline
+func VLine(x int, y int, len int)
+
 /** Draws an oval (or circle). */
 //go:export oval
 func Oval(x int, y int, width uint, height uint)

--- a/cli/assets/templates/go/w4/wasm4.go
+++ b/cli/assets/templates/go/w4/wasm4.go
@@ -64,11 +64,11 @@ func Line(x1 int, y1 int, x2 int, y2 int)
 
 /** Draws a horizontal line. */
 //go:export hline
-func HLine(x int, y int, len int)
+func HLine(x int, y int, len uint)
 
 /** Draws a vertical line. */
 //go:export vline
-func VLine(x int, y int, len int)
+func VLine(x int, y int, len uint)
 
 /** Draws an oval (or circle). */
 //go:export oval

--- a/cli/assets/templates/rust/src/wasm4.rs
+++ b/cli/assets/templates/rust/src/wasm4.rs
@@ -40,21 +40,53 @@ pub const BUTTON_DOWN: u8 = 128;
 // └───────────────────────────────────────────────────────────────────────────┘
 
 /// Copies pixels to the framebuffer.
-pub fn blit (sprite: &[u8], x: i32, y: i32, width: u32, height: u32, flags: u32) {
+pub fn blit(sprite: &[u8], x: i32, y: i32, width: u32, height: u32, flags: u32) {
     unsafe { extern_blit(sprite.as_ptr(), x, y, width, height, flags) }
 }
-extern {
+extern "C" {
     #[link_name = "blit"]
-    fn extern_blit (sprite: *const u8, x: i32, y: i32, width: u32, height: u32, flags: u32);
+    fn extern_blit(sprite: *const u8, x: i32, y: i32, width: u32, height: u32, flags: u32);
 }
 
 /// Copies a subregion within a larger sprite atlas to the framebuffer.
-pub fn blit_sub (sprite: &[u8], x: i32, y: i32, width: u32, height: u32, src_x: u32, src_y: u32, stride: u32, flags: u32) {
-    unsafe { extern_blit_sub(sprite.as_ptr(), x, y, width, height, src_x, src_y, stride, flags) }
+pub fn blit_sub(
+    sprite: &[u8],
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+    src_x: u32,
+    src_y: u32,
+    stride: u32,
+    flags: u32,
+) {
+    unsafe {
+        extern_blit_sub(
+            sprite.as_ptr(),
+            x,
+            y,
+            width,
+            height,
+            src_x,
+            src_y,
+            stride,
+            flags,
+        )
+    }
 }
-extern {
+extern "C" {
     #[link_name = "blitSub"]
-    fn extern_blit_sub (sprite: *const u8, x: i32, y: i32, width: u32, height: u32, src_x: u32, src_y: u32, stride: u32, flags: u32);
+    fn extern_blit_sub(
+        sprite: *const u8,
+        x: i32,
+        y: i32,
+        width: u32,
+        height: u32,
+        src_x: u32,
+        src_y: u32,
+        stride: u32,
+        flags: u32,
+    );
 }
 
 pub const BLIT_2BPP: u32 = 1;
@@ -64,39 +96,63 @@ pub const BLIT_FLIP_Y: u32 = 4;
 pub const BLIT_ROTATE: u32 = 8;
 
 /// Draws a line between two points.
-pub fn line (x1: i32, y1: i32, x2: i32, y2: i32) {
+pub fn line(x1: i32, y1: i32, x2: i32, y2: i32) {
     unsafe { extern_line(x1, y1, x2, y2) }
 }
-extern {
+extern "C" {
     #[link_name = "line"]
-    fn extern_line (x1: i32, y1: i32, x2: i32, y2: i32);
+    fn extern_line(x1: i32, y1: i32, x2: i32, y2: i32);
 }
 
 /// Draws an oval (or circle).
-pub fn oval (x: i32, y: i32, width: u32, height: u32) {
+pub fn oval(x: i32, y: i32, width: u32, height: u32) {
     unsafe { extern_oval(x, y, width, height) }
 }
-extern {
+extern "C" {
     #[link_name = "oval"]
-    fn extern_oval (x: i32, y: i32, width: u32, height: u32);
+    fn extern_oval(x: i32, y: i32, width: u32, height: u32);
 }
 
 /// Draws a rectangle.
-pub fn rect (x: i32, y: i32, width: u32, height: u32) {
+pub fn rect(x: i32, y: i32, width: u32, height: u32) {
     unsafe { extern_rect(x, y, width, height) }
 }
-extern {
+extern "C" {
     #[link_name = "rect"]
-    fn extern_rect (x: i32, y: i32, width: u32, height: u32);
+    fn extern_rect(x: i32, y: i32, width: u32, height: u32);
 }
 
 /// Draws text using the built-in system font.
-pub fn text (text: &str, x: i32, y: i32) {
+pub fn text(text: &str, x: i32, y: i32) {
     unsafe { extern_text(text.as_ptr(), text.len(), x, y) }
 }
-extern {
+extern "C" {
     #[link_name = "textUtf8"]
-    fn extern_text (text: *const u8, length: usize, x: i32, y: i32);
+    fn extern_text(text: *const u8, length: usize, x: i32, y: i32);
+}
+
+/// Draws a vertical line
+pub fn vline(x: i32, y: i32, len: i32) {
+    unsafe {
+        extern_vline(x, y, len);
+    }
+}
+
+extern "C" {
+    #[link_name = "vline"]
+    fn extern_vline(x: i32, y: i32, len: i32);
+}
+
+/// Draws a horizontal line
+pub fn hline(x: i32, y: i32, len: i32) {
+    unsafe {
+        extern_hline(x, y, len);
+    }
+}
+
+extern "C" {
+    #[link_name = "hline"]
+    fn extern_hline(x: i32, y: i32, len: i32);
 }
 
 // ┌───────────────────────────────────────────────────────────────────────────┐
@@ -106,12 +162,12 @@ extern {
 // └───────────────────────────────────────────────────────────────────────────┘
 
 /// Plays a sound tone.
-pub fn tone (frequency: u32, duration: u32, volume: u32, flags: u32) {
+pub fn tone(frequency: u32, duration: u32, volume: u32, flags: u32) {
     unsafe { extern_tone(frequency, duration, volume, flags) }
 }
-extern {
+extern "C" {
     #[link_name = "tone"]
-    fn extern_tone (frequency: u32, duration: u32, volume: u32, flags: u32);
+    fn extern_tone(frequency: u32, duration: u32, volume: u32, flags: u32);
 }
 
 pub const TONE_PULSE1: u32 = 0;
@@ -129,12 +185,12 @@ pub const TONE_MODE4: u32 = 12;
 // │                                                                           │
 // └───────────────────────────────────────────────────────────────────────────┘
 
-extern {
+extern "C" {
     /// Reads up to `size` bytes from persistent storage into the pointer `dest`.
-    pub fn diskr (dest: *mut u8, size: u32) -> u32;
+    pub fn diskr(dest: *mut u8, size: u32) -> u32;
 
     /// Writes up to `size` bytes from the pointer `src` into persistent storage.
-    pub fn diskw (src: *const u8, size: u32) -> u32;
+    pub fn diskw(src: *const u8, size: u32) -> u32;
 }
 
 // ┌───────────────────────────────────────────────────────────────────────────┐
@@ -144,10 +200,10 @@ extern {
 // └───────────────────────────────────────────────────────────────────────────┘
 
 /// Prints a message to the debug console.
-pub fn trace (text: &str) {
+pub fn trace(text: &str) {
     unsafe { extern_trace(text.as_ptr(), text.len()) }
 }
-extern {
+extern "C" {
     #[link_name = "traceUtf8"]
-    fn extern_trace (trace: *const u8, length: usize);
+    fn extern_trace(trace: *const u8, length: usize);
 }

--- a/cli/assets/templates/rust/src/wasm4.rs
+++ b/cli/assets/templates/rust/src/wasm4.rs
@@ -132,7 +132,7 @@ extern "C" {
 }
 
 /// Draws a vertical line
-pub fn vline(x: i32, y: i32, len: i32) {
+pub fn vline(x: i32, y: i32, len: u32) {
     unsafe {
         extern_vline(x, y, len);
     }
@@ -140,11 +140,11 @@ pub fn vline(x: i32, y: i32, len: i32) {
 
 extern "C" {
     #[link_name = "vline"]
-    fn extern_vline(x: i32, y: i32, len: i32);
+    fn extern_vline(x: i32, y: i32, len: u32);
 }
 
 /// Draws a horizontal line
-pub fn hline(x: i32, y: i32, len: i32) {
+pub fn hline(x: i32, y: i32, len: u32) {
     unsafe {
         extern_hline(x, y, len);
     }
@@ -152,7 +152,7 @@ pub fn hline(x: i32, y: i32, len: i32) {
 
 extern "C" {
     #[link_name = "hline"]
-    fn extern_hline(x: i32, y: i32, len: i32);
+    fn extern_hline(x: i32, y: i32, len: u32);
 }
 
 // ┌───────────────────────────────────────────────────────────────────────────┐

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "wasm4",
-      "version": "1.0.4",
+      "version": "1.0.7",
       "license": "ISC",
       "dependencies": {
         "commander": "^8.2.0",

--- a/runtimes/web/src/framebuffer.js
+++ b/runtimes/web/src/framebuffer.js
@@ -8,12 +8,7 @@ import {
 
 function getStrokeColor(drawColors) {
     const dc0 = drawColors[0] & 0xf;
-
-    if (dc0 === 0) {
-        return 0;
-    }
-
-    return (dc0 - 1) & 0x3
+    return dc0 ? (dc0 - 1) & 0x3 : 0;
 }
 
 export class Framebuffer {

--- a/runtimes/web/src/framebuffer.js
+++ b/runtimes/web/src/framebuffer.js
@@ -34,61 +34,42 @@ export class Framebuffer {
         }
     }
 
-    drawHLineInternal(color, x, y, len) {
-        if (y > HEIGHT || y < 0 || len === 0) {
+    drawHLine(x, y, len) {
+        if (x + len <= 0 || y < 0 || y >= HEIGHT) {
+            return;
+        }   
+ 
+        const color = getStrokeColor(this.drawColors);
+
+        if(color === 0) {
             return;
         }
-        let startX, endX;
 
-        if(len < 0) {
-            startX = Math.max(0, x + len + 1);
-            endX = Math.min(WIDTH, x + 1);
-        } else {
-            startX = Math.max(0, x);
-            endX = Math.min(x + len, WIDTH);
-        }
+        const startX = Math.max(0, x);
+        const endX = Math.min(WIDTH, x + len);
 
-        for (let xx = startX; xx < endX; ++xx) {
+        for(let xx = startX; xx < endX; xx++) {
             this.drawPoint(color, xx, y);
         }
     }
 
-    drawVLineInternal(color, x, y, len) {
-        if (x > WIDTH || x < 0 || len === 0) {
+    drawVLine(x, y, len) {
+        if (y + len <= 0 || x < 0 || x >= WIDTH) {
+            return;
+        }          
+ 
+        const color = getStrokeColor(this.drawColors);
+
+        if(color === 0) {
             return;
         }
 
-        let startY,endY;
+        const startY = Math.max(0, y);
+        const endY = Math.min(HEIGHT, y + len);
 
-        if (len < 0) {
-            startY = Math.max(0, y + len + 1);
-            endY = Math.min(HEIGHT, y + 1);
-        } else {
-            startY = Math.max(0, y);
-            endY = Math.min(HEIGHT, y + len);
-        }
-
-        for (let yy = startY; yy < endY; ++yy) {
+        for(let yy = startY; yy < endY; yy++) {
             this.drawPoint(color, x, yy);
         }
-    }
-
-    drawHLine(x, y, len) {
-        const strokeColor = getStrokeColor(this.drawColors);
-
-        if(strokeColor === 0) {
-            return;
-        }
-        this.drawHLineInternal(strokeColor, x, y, len);
-    }
-
-    drawVLine(x, y, len) {
-        const strokeColor = getStrokeColor(this.drawColors);
-
-        if(strokeColor === 0) {
-            return;
-        }
-        this.drawVLineInternal(strokeColor, x, y, len);
     }
 
     drawRect(x, y, width, height) {

--- a/runtimes/web/src/framebuffer.js
+++ b/runtimes/web/src/framebuffer.js
@@ -34,40 +34,66 @@ export class Framebuffer {
         }
     }
 
+    drawHLineInternal(color, startX, y, endX) {
+        const fillEnd = endX - (endX % 4);
+        const fillStart = Math.min((startX + 3) & ~0x03, fillEnd);
+
+        if (fillEnd - fillStart >= 4) {
+            for (let xx = startX; xx < fillStart; xx++) {
+                this.drawPoint(color, xx, y);
+            }
+
+            if (fillEnd - fillStart >= 4) {
+                const from = (WIDTH * y + fillStart) >>> 2;
+                const to = (WIDTH * y + fillEnd) >>> 2;
+                const fillColor =
+                    (color << 6) | (color << 4) | (color << 2) | color;
+
+                this.bytes.fill(fillColor, from, to);
+            }
+
+            for (let xx = fillEnd; xx < endX; xx++) {
+                this.drawPoint(color, xx, y);
+            }
+        } else {
+            for (let xx = startX; xx < endX; xx++) {
+                this.drawPoint(color, xx, y);
+            }
+        }
+    }
+
     drawHLine(x, y, len) {
         if (x + len <= 0 || y < 0 || y >= HEIGHT) {
             return;
-        }   
- 
+        }
+
         const color = getStrokeColor(this.drawColors);
 
-        if(color === 0) {
+        if (color === 0) {
             return;
         }
 
         const startX = Math.max(0, x);
         const endX = Math.min(WIDTH, x + len);
 
-        for(let xx = startX; xx < endX; xx++) {
-            this.drawPoint(color, xx, y);
-        }
+        this.drawHLineInternal(color, startX, y, endX);
     }
 
     drawVLine(x, y, len) {
         if (y + len <= 0 || x < 0 || x >= WIDTH) {
             return;
-        }          
- 
+        }
+
         const color = getStrokeColor(this.drawColors);
 
-        if(color === 0) {
+        if (color === 0) {
             return;
         }
 
         const startY = Math.max(0, y);
         const endY = Math.min(HEIGHT, y + len);
 
-        for(let yy = startY; yy < endY; yy++) {
+        for (let yy = startY; yy < endY; yy++) {
             this.drawPoint(color, x, yy);
         }
     }

--- a/runtimes/web/src/runtime.js
+++ b/runtimes/web/src/runtime.js
@@ -97,6 +97,9 @@ export class Runtime {
             oval: this.framebuffer.drawOval.bind(this.framebuffer),
             line: this.framebuffer.drawLine.bind(this.framebuffer),
 
+            hline: this.framebuffer.drawHLine.bind(this.framebuffer),
+            vline: this.framebuffer.drawVLine.bind(this.framebuffer),
+
             text: this.text.bind(this),
             textUtf8: this.textUtf8.bind(this),
             textUtf16: this.textUtf16.bind(this),

--- a/site/docs/reference/functions.md
+++ b/site/docs/reference/functions.md
@@ -68,6 +68,22 @@ Draws a rectangle.
 
 `DRAW_COLORS` color 1 is used as the fill color, `DRAW_COLORS` color 2 is used as the outline color.
 
+### `hline(x, y, len)`
+
+Draws a horizontal line from point `(x; y)`.
+
+Draws forward if `len` is greater than 0, from `(x; y)` to `(x + len; y)` excluded.
+
+Draws backwards if `len` is lower than 0, from `(x; y)` to `(x + len; y)` excluded.
+
+### `vline(x, y, len)`
+
+Draws a vertical line from point `(x; y)`, `(x; y)`
+
+Draws forward if `len` is greater than 0, from `(x; y)` to `(x; y + len)` excluded.
+
+Draws backwards if `len` is lower than 0, from `(x; y)` to `(x; y + len)` excluded.
+
 ### `text (str, x, y)`
 
 Draws text using the built-in system font. The string may contain new-line (`\n`) characters.

--- a/site/docs/reference/functions.md
+++ b/site/docs/reference/functions.md
@@ -70,19 +70,11 @@ Draws a rectangle.
 
 ### `hline(x, y, len)`
 
-Draws a horizontal line from point `(x; y)`.
-
-Draws forward if `len` is greater than 0, from `(x; y)` to `(x + len; y)` excluded.
-
-Draws backwards if `len` is lower than 0, from `(x; y)` to `(x + len; y)` excluded.
+Draws a horizontal line between `(x; y)` and `(x + len - 1; y)`.
 
 ### `vline(x, y, len)`
 
-Draws a vertical line from point `(x; y)`, `(x; y)`
-
-Draws forward if `len` is greater than 0, from `(x; y)` to `(x; y + len)` excluded.
-
-Draws backwards if `len` is lower than 0, from `(x; y)` to `(x; y + len)` excluded.
+Draws a vertical line between `(x; y)` and `(x; y + len - 1)`.
 
 ### `text (str, x, y)`
 


### PR DESCRIPTION
## Description

This PR adds hline and vline functions and closes #74

#### HLINE

```typescript
@external("env", "hline")
export declare function hline (x: i32, y: i32, len: i32): void;
```

Draws a horizontal line from `(x;y)`.
If `len` is greater than `0` draws from `(x; y)` to `(x + len; y)` excluded.
if `len` is lower than `0` draws from `(x + len + 1; y)` to `(x + 1; y)` excluded.

#### VLINE

```typescript
@external("env", "vline")
export declare function vline (x: i32, y: i32, len: i32): void;
```

Draws a vertical line from `(x;y)`.
If `len` is greater than `0` draws from `(x; y)` to `(x; y + len)` excluded.
if `len` is lower than `0` draws from `(x; y + len + 1)` to `(x; y + 1)` excluded.

### To do

- [x]  update documentation
- [ ]  apply feedback provided
- [ ]  Evaluate the possibility to use `drawHLineInternal` and `drawVLineInternal` in `rect` and `oval`. 
