### PR TITLE
feat: Gamepad

### DIFF
--- a/runtimes/web/src/index.js
+++ b/runtimes/web/src/index.js
@@ -274,15 +274,6 @@ async function loadCartWasm () {
     }
 
     window.addEventListener("gamepadconnected", (e) => {
-        const gp = navigator.getGamepads()[e.gamepad.index];
-        console.log(
-          "Gamepad connected at index %d: %s. %d buttons, %d axes.",
-          gp.index,
-          gp.id,
-          gp.buttons.length,
-          gp.axes.length
-        );
-
         gamepads ++;
     });
 

--- a/runtimes/web/src/index.js
+++ b/runtimes/web/src/index.js
@@ -288,17 +288,7 @@ async function loadCartWasm () {
 
     window.addEventListener('gamepaddisconnected', (e) => {
         gamepads --;
-
-        // https://www.w3.org/TR/gamepad/#remapping
-        // DPAD + AXIS
-        runtime.maskGamepad(0, constants.BUTTON_UP, false);
-        runtime.maskGamepad(0, constants.BUTTON_DOWN, false);
-        runtime.maskGamepad(0, constants.BUTTON_LEFT, false);
-        runtime.maskGamepad(0, constants.BUTTON_RIGHT, false);
-
-        // X, O + Triggers
-        runtime.maskGamepad(0, constants.BUTTON_X, false);
-        runtime.maskGamepad(0, constants.BUTTON_Z, false);
+        runtime.maskGamepad(0,0, false);
     });
 
     const dpad = document.getElementById("gamepad-dpad");

--- a/runtimes/web/src/index.js
+++ b/runtimes/web/src/index.js
@@ -197,8 +197,17 @@ async function loadCartWasm () {
         122: requestFullscreen, // F11
     };
 
+    let isKeyboard = true;
+
     const onKeyboardEvent = event => {
         const down = (event.type == "keydown");
+
+        if (!isKeyboard) {
+            // reset joy pad state
+            runtime.setGamepad(0,0);
+        }
+
+        isKeyboard = true;
 
         // Poke WebAudio
         runtime.unlockAudio();
@@ -245,41 +254,81 @@ async function loadCartWasm () {
     window.addEventListener("keydown", onKeyboardEvent);
     window.addEventListener("keyup", onKeyboardEvent);
 
-    let gamepads = 0;
+    let usedGamepad = -1;
+
     function processGamepad() {
-        if (gamepads === 0) {
+        if (usedGamepad === -1) {
             return;
         }
 
-        const gamepad = navigator.getGamepads()[0];
+        const gamepad = navigator.getGamepads()[usedGamepad];
         if (!gamepad) {
-
             return;
         }
 
         const buttons = gamepad.buttons;
         const axes = gamepad.axes;
+        
+        // not all gamepads map DPAD to 12,13, 14, 15 buttos
+        const dpad = buttons.length > 12;
 
         // https://www.w3.org/TR/gamepad/#remapping
         // DPAD + AXIS
-        runtime.maskGamepad(0, constants.BUTTON_UP, buttons[12].pressed || axes[1] < -0.5);
-        runtime.maskGamepad(0, constants.BUTTON_DOWN, buttons[13].pressed || axes[1] > 0.5);
-        runtime.maskGamepad(0, constants.BUTTON_LEFT, buttons[14].pressed || axes[0] < -0.5);
-        runtime.maskGamepad(0, constants.BUTTON_RIGHT, buttons[15].pressed || axes[0] > 0.5);
+        const up = +(dpad && buttons[12].pressed || axes[1] < -0.5);
+        const down = +(dpad && buttons[13].pressed || axes[1] > 0.5);
+        const left = +(dpad && buttons[14].pressed || axes[0] < -0.5);
+        const right = +(dpad && buttons[15].pressed || axes[0] > 0.5);
 
         // X, O + Triggers
         // NOTE: for XBox360 a triggers is 6 and 7
-        runtime.maskGamepad(0, constants.BUTTON_X, buttons[0].pressed || buttons[6].pressed);
-        runtime.maskGamepad(0, constants.BUTTON_Z, buttons[1].pressed || buttons[7].pressed);
+        const x = +(buttons[0].pressed || buttons[6].pressed);
+        const z = +(buttons[1].pressed || buttons[7].pressed);
+
+
+        let buttonMask = 0;
+        buttonMask |= constants.BUTTON_UP * up;
+        buttonMask |= constants.BUTTON_DOWN * down;
+        buttonMask |= constants.BUTTON_LEFT * left;
+        buttonMask |= constants.BUTTON_RIGHT * right;
+
+        buttonMask |= constants.BUTTON_X * x;
+        buttonMask |= constants.BUTTON_Z * z;
+
+        // supress changing if keyboard used
+        // we should not reset state but should read it
+        if (buttonMask !== 0 || !isKeyboard) {
+            isKeyboard = false;
+
+            runtime.setGamepad(0, buttonMask);
+        }
     }
 
     window.addEventListener("gamepadconnected", (e) => {
-        gamepads ++;
+        // find a first active gamepad
+        for(const g of navigator.getGamepads()) {
+            if (g) {
+                usedGamepad = g.index;
+                break;
+            }
+        }
     });
 
     window.addEventListener('gamepaddisconnected', (e) => {
-        gamepads --;
-        runtime.maskGamepad(0,0, false);
+        // if gamepad is same - nothing doing
+        if (e.gamepad.index !== usedGamepad) {
+            return;
+        }
+
+        // reset 
+        usedGamepad = -1;
+        runtime.setGamepad(0, 0);
+
+        for(const g of navigator.getGamepads()) {
+            if (g) {
+                usedGamepad = g.index;
+                break;
+            }
+        }
     });
 
     const dpad = document.getElementById("gamepad-dpad");

--- a/runtimes/web/src/index.js
+++ b/runtimes/web/src/index.js
@@ -334,6 +334,7 @@ async function loadCartWasm () {
             const DPAD_MAX_DISTANCE = 100;
             const DPAD_DEAD_ZONE = 10;
             const BUTTON_MAX_DISTANCE = 50;
+            const DPAD_ACTIVE_ZONE = 3 / 5; // cos of active angle, greater that cos 60 (1/2)
 
             const dpadBounds = dpad.getBoundingClientRect();
             const dpadX = dpadBounds.x + dpadBounds.width/2;
@@ -347,19 +348,24 @@ async function loadCartWasm () {
             const action2X = action2Bounds.x + action2Bounds.width/2;
             const action2Y = action2Bounds.y + action2Bounds.height/2;
 
-            let x, y;
+            let x, y, dist, cosX, cosY;
             for (let touch of touchEvents.values()) {
                 x = touch.clientX - dpadX;
                 y = touch.clientY - dpadY;
-                if (x*x + y*y < DPAD_MAX_DISTANCE*DPAD_MAX_DISTANCE) {
-                    if (x < -DPAD_DEAD_ZONE) {
+                dist = Math.sqrt( x*x + y * y );
+
+                if (dist < DPAD_MAX_DISTANCE && dist > DPAD_DEAD_ZONE) {
+                    cosX = x / dist;
+                    cosY = y / dist;
+
+                    if (-cosX > DPAD_ACTIVE_ZONE) {
                         buttons |= constants.BUTTON_LEFT;
-                    } else if (x > DPAD_DEAD_ZONE) {
+                    } else if (cosX > DPAD_ACTIVE_ZONE) {
                         buttons |= constants.BUTTON_RIGHT;
                     }
-                    if (y < -DPAD_DEAD_ZONE) {
+                    if (-cosY > DPAD_ACTIVE_ZONE) {
                         buttons |= constants.BUTTON_UP;
-                    } else if (y > DPAD_DEAD_ZONE) {
+                    } else if (cosY > DPAD_ACTIVE_ZONE) {
                         buttons |= constants.BUTTON_DOWN;
                     }
                 }

--- a/runtimes/web/src/index.js
+++ b/runtimes/web/src/index.js
@@ -274,25 +274,24 @@ async function loadCartWasm () {
 
         // https://www.w3.org/TR/gamepad/#remapping
         // DPAD + AXIS
-        const up = +(dpad && buttons[12].pressed || axes[1] < -0.5);
-        const down = +(dpad && buttons[13].pressed || axes[1] > 0.5);
-        const left = +(dpad && buttons[14].pressed || axes[0] < -0.5);
-        const right = +(dpad && buttons[15].pressed || axes[0] > 0.5);
+        const up = dpad && buttons[12].pressed || axes[1] < -0.5;
+        const down = dpad && buttons[13].pressed || axes[1] > 0.5;
+        const left = dpad && buttons[14].pressed || axes[0] < -0.5;
+        const right = dpad && buttons[15].pressed || axes[0] > 0.5;
 
         // X, O + Triggers
         // NOTE: for XBox360 a triggers is 6 and 7
-        const x = +(buttons[0].pressed || buttons[6].pressed);
-        const z = +(buttons[1].pressed || buttons[7].pressed);
-
+        const x = buttons[0].pressed || buttons[6].pressed;
+        const z = buttons[1].pressed || buttons[7].pressed;
 
         let buttonMask = 0;
-        buttonMask |= constants.BUTTON_UP * up;
-        buttonMask |= constants.BUTTON_DOWN * down;
-        buttonMask |= constants.BUTTON_LEFT * left;
-        buttonMask |= constants.BUTTON_RIGHT * right;
+        buttonMask |= constants.BUTTON_UP & -up;
+        buttonMask |= constants.BUTTON_DOWN & -down;
+        buttonMask |= constants.BUTTON_LEFT & -left;
+        buttonMask |= constants.BUTTON_RIGHT & -right;
 
-        buttonMask |= constants.BUTTON_X * x;
-        buttonMask |= constants.BUTTON_Z * z;
+        buttonMask |= constants.BUTTON_X & -x;
+        buttonMask |= constants.BUTTON_Z & -z;
 
         // supress changing if keyboard used
         // we should not reset state but should read it


### PR DESCRIPTION
Fix #104 

Support native gamepad.
Now only first gamepad is used.

DPAD + LEFT AXIS - movement
X, O (DS4 mapping) - X, Z
LEFT/RIGHT Triggers - X, Z

Sometimes joys swap a buttons order for right buttons panel, need investigate this case.

This is feature a runtime, this means that need rebundle games.

UPD:
If you trigger a keyboard or gamepad in game - last input device will be used. You can change gamepad/keyboard on fly.
First connected gamepad is used on multiple gamepad system , and replaced on latest available after disconnection.