### PR TITLE
docs: add rust examples to saving-data.md

### DIFF
--- a/site/docs/guides/saving-data.md
+++ b/site/docs/guides/saving-data.md
@@ -25,7 +25,12 @@ diskw(&gameData, sizeof(gameData));
 ```
 
 ```rust
-// Rust example coming soon 🦀
+let game_data: i32 = 1337;
+
+unsafe {
+    let game_data_bytes = game_data.to_le_bytes();
+    diskw(game_data_bytes.as_ptr(), core::mem::size_of::<i32>() as u32);
+}
 ```
 
 ```go
@@ -60,7 +65,13 @@ diskr(&gameData, sizeof(gameData));
 ```
 
 ```rust
-// Rust example coming soon 🦀
+let game_data = unsafe {
+    let mut buffer = [0u8; core::mem::size_of::<i32>()];
+
+    diskr(buffer.as_mut_ptr(), buffer.len() as u32);
+
+    i32::from_le_bytes(buffer)
+};
 ```
 
 ```go


### PR DESCRIPTION
Adds missing rust examples to the saving-data.md