### PR TITLE
Refact Rect and Oval onto  vline/hline + oval fill

### DIFF
--- a/runtimes/web/src/framebuffer.js
+++ b/runtimes/web/src/framebuffer.js
@@ -176,9 +176,12 @@ export class Framebuffer {
                 this.drawPointUnclipped(strokeColor, x0 - x, y0 + y); /* III. Quadrant */
                 this.drawPointUnclipped(strokeColor, x0 - x, y0 - y); /*  IV. Quadrant */
 
-                if (dc0 !== 0) {
-                    this.drawHLineInternal(fillColor, x0 - x + 1, y0 + y, x0 + x); /*   I and III. Quadrant */
-                    this.drawHLineInternal(fillColor, x0 - x + 1, y0 - y, x0 + x); /*  II and IV. Quadrant */
+                const start = Math.max(x0 - x + 1, 0);
+                const end = Math.min(x0 + x, WIDTH);
+
+                if (dc0 !== 0 && (end - start) > 0) {
+                    this.drawHLineInternal(fillColor, start, y0 + y, end); /*   I and III. Quadrant */
+                    this.drawHLineInternal(fillColor, start, y0 - y, end); /*  II and IV. Quadrant */
                 }
 
                 y++; sy += aa2; e += dy; dy += aa2;
@@ -203,11 +206,15 @@ export class Framebuffer {
 
                 x++; sx += bb2; e += dx; dx += bb2; ddx++;
                 if (2 * e + dy > 0) {
-
                     if (dc0 !== 0) {
                         const w = x - ddx - 1;
-                        this.drawHLineInternal(fillColor, x0 - w, y0 + y, x0 + w + 1); /*   I and III. Quadrant */
-                        this.drawHLineInternal(fillColor, x0 - w, y0 - y, x0 + w + 1); /*  II and IV. Quadrant */
+                        const start = Math.max(x0 - w, 0);
+                        const end = Math.min(x0 + w + 1, WIDTH);
+                        
+                        if (end - start > 0) {
+                            this.drawHLineInternal(fillColor, start, y0 + y, end); /*   I and III. Quadrant */
+                            this.drawHLineInternal(fillColor, start, y0 - y, end); /*  II and IV. Quadrant */
+                        }
                     }
 
                     y--; sy -= aa2; e += dy; dy += aa2; ddx = 0;

--- a/runtimes/web/src/framebuffer.js
+++ b/runtimes/web/src/framebuffer.js
@@ -109,13 +109,12 @@ export class Framebuffer {
         const drawColors = this.drawColors[0];
         const dc0 = drawColors & 0xf;
         const dc1 = (drawColors >>> 4) & 0xf;
+        const offset = +(dc1 !== 0)
 
         if (dc0 !== 0) {
             const fillColor = (dc0 - 1) & 0x3;
-            for (let yy = startY; yy < endY; ++yy) {
-                for (let xx = startX; xx < endX; ++xx) {
-                    this.drawPoint(fillColor, xx, yy);
-                }
+            for (let yy = startY + offset; yy < endY - offset; ++yy) {
+                this.drawHLineInternal(fillColor, startX + offset, yy, endX - offset);
             }
         }
 
@@ -124,31 +123,23 @@ export class Framebuffer {
 
             // Left edge
             if (x >= 0 && x < WIDTH) {
-                for (let yy = startY; yy < endY; ++yy) {
+                for (let yy = startY; yy < endY - 1; ++yy) {
                     this.drawPoint(strokeColor, x, yy);
                 }
             }
 
             // Right edge
             if (endX > 0 && endXUnclamped < WIDTH + 1) {
-                for (let yy = startY; yy < endY; ++yy) {
+                for (let yy = startY; yy < endY - 1; ++yy) {
                     this.drawPoint(strokeColor, endX - 1, yy);
                 }
             }
 
             // Top edge
-            if (y >= 0 && y < HEIGHT) {
-                for (let xx = startX; xx < endX; ++xx) {
-                    this.drawPoint(strokeColor, xx, y);
-                }
-            }
+            this.drawHLineInternal (strokeColor, startX, startY, endX);
 
             // Bottom edge
-            if (endY > 0 && endYUnclamped < HEIGHT + 1) {
-                for (let xx = startX; xx < endX; ++xx) {
-                    this.drawPoint(strokeColor, xx, endY - 1);
-                }
-            }
+            this.drawHLineInternal (strokeColor, startX, endY - 1, endX);
         }
     }
 


### PR DESCRIPTION
Fix: #13 

Hah, oval has bug - It sometime skip lines (include a outline)

test:
```typescript
import * as w4 from "./wasm4";

let sx: u32 = 4;
let sy : u32 = 4;

let last: u32 = 0;

export function update (): void {
    const gamepad = load<u8>(w4.GAMEPAD1);
    const press = gamepad;// & (gamepad ^ last);
    last = gamepad;

    if((press & w4.BUTTON_LEFT) !== 0) {
        sx --;
    }
    if((press & w4.BUTTON_RIGHT) !== 0) {
        sx ++;
    }
    if((press & w4.BUTTON_UP) !== 0) {
        sy --;
    }
    if((press & w4.BUTTON_DOWN) !== 0) {
        sy ++;
    }
    
    store<u16>(w4.DRAW_COLORS, 0x2);

    w4.text ("New Rect", 4, 4);
    w4.text ("O:" + sx.toString() + ',' + sy.toString(), 84, 4);

    store<u16>(w4.DRAW_COLORS, 0x32);

    w4.rect (4, 12, sx + 1, sy + 1);

    w4.oval (80 + 4, 12, sx + 1, sy + 1);
}

```

![wasm4-screenshot (1)](https://user-images.githubusercontent.com/12572222/134771726-f0dc379a-6ca8-45f3-a6a7-2f3625605834.png)
