### PR TITLE
Added error logging to window creation

### DIFF
--- a/runtimes/native/src/impl/window_glfw.c
+++ b/runtimes/native/src/impl/window_glfw.c
@@ -122,8 +122,19 @@ static void onFramebufferResized (GLFWwindow* window, int width, int height) {
     glViewport(x, y, size, size);
 }
 
+static void onGlfwError(int error, const char* description)
+{
+    fprintf(stderr,"%s\n",description);
+}
+
+
 void w4_windowBoot (const char* title) {
-    glfwInit();
+    if(!glfwInit()){
+        fprintf(stderr,"Failed to initialise GLFW.");
+        return;
+    }
+
+    glfwSetErrorCallback(onGlfwError);
 
     glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);


### PR DESCRIPTION
Some minor changes I made to assist debugging issues on macOS. Print error message on glfwInit fail. Setup callback for GLFW error.