### PR TITLE
Hotswap palette reset fix

### DIFF
--- a/runtimes/web/src/index.js
+++ b/runtimes/web/src/index.js
@@ -87,6 +87,8 @@ async function loadCartWasm () {
                 const wasmBuffer = await loadCartWasm();
                 if (event.data == "reload") {
                     runtime.reset(true);
+                } else {
+                    runtime.reset(false);
                 }
                 await runtime.load(wasmBuffer);
                 runtime.start();


### PR DESCRIPTION
When using 'w4 watch'  the palette now resets to default when hotswapping in a new cart.