### PR TITLE
Changed Go template

### DIFF
--- a/cli/assets/templates/go/Makefile
+++ b/cli/assets/templates/go/Makefile
@@ -18,7 +18,7 @@ WASM_OPT_FLAGS = -Oz --zero-filled-memory --strip-producers
 
 all:
 	@mkdir -p build
-	$(GO) build $(GOFLAGS) -o build/cart.wasm ./...
+	$(GO) build $(GOFLAGS) -o build/cart.wasm .
 ifneq ($(DEBUG), 1)
 ifeq (, $(shell which $(WASM_OPT)))
 	@echo Tip: $(WASM_OPT) was not found. Install it from binaryen for smaller builds!

--- a/cli/assets/templates/go/go.mod
+++ b/cli/assets/templates/go/go.mod
@@ -1,3 +1,3 @@
 module cart
 
-go 1.13
+go 1.16


### PR DESCRIPTION
- Bumped Go-Version in go.mod from 1.13 to 1.16
- Changed Makefile to remove ./...

Go Version 1.13 can cause trouble with Go-Modules. Especially with the
vendor-Folder.

For the same reason, the ./... was removed. TinyGo tries to compile the
vendor-Folder as a main-package otherwise.