### PR TITLE
bump rust edition to 2021

### DIFF
--- a/cli/assets/templates/rust/Cargo.toml
+++ b/cli/assets/templates/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cart"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/examples/pong/.cargo/config.toml
+++ b/examples/pong/.cargo/config.toml
@@ -10,8 +10,9 @@ rustflags = [
     "-C", "link-arg=--initial-memory=65536",
     "-C", "link-arg=--max-memory=65536",
 
-    # Reserve 1024 bytes of stack space, offset from 6580
-    "-C", "link-arg=-zstack-size=7584",
+    # Reserve 2044 bytes of stack space, offset from 6580.
+    # Bump this value, 16-byte aligned, if the framebuffer gets corrupted.
+    "-C", "link-arg=-zstack-size=8624",
 
     # Not working? https://github.com/rust-lang/rust/issues/46645#issuecomment-423912553
     # "-C", "link-arg=--global-base=6560",

--- a/examples/pong/Cargo.toml
+++ b/examples/pong/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pong"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/pong/src/lib.rs
+++ b/examples/pong/src/lib.rs
@@ -44,5 +44,5 @@ fn panic_handler(_panic_info: &core::panic::PanicInfo<'_>) -> ! {
         trace(cause);
     }
 
-    unsafe { wasm32::unreachable() }
+    wasm32::unreachable()
 }


### PR DESCRIPTION
### Description

Bumps edition in rust starting template and pong example to `2021`.

### Other changes

- chore: update .cargo/config.toml in pong
- refactor: remove unnecessary unsafe block

### References

- https://doc.rust-lang.org/edition-guide/rust-2021/index.html
- https://doc.rust-lang.org/edition-guide/editions/index.html
- https://blog.rust-lang.org/2021/05/11/edition-2021.html