### PR TITLE
feat: add `wasm4::seed` in rust template

### DIFF
--- a/cli/assets/templates/rust/src/wasm4.rs
+++ b/cli/assets/templates/rust/src/wasm4.rs
@@ -217,3 +217,13 @@ extern "C" {
     #[link_name = "traceUtf8"]
     fn extern_trace(trace: *const u8, length: usize);
 }
+
+/// Returns a random `u64`.
+pub fn seed() -> u64 {
+    unsafe { extern_seed() as u64 }
+}
+
+extern "C" {
+    #[link_name = "seed"]
+    fn extern_seed() -> f64;
+}


### PR DESCRIPTION
### Description

Adds binding to `seed` in rust template.

### Why

Seed is a randomness source that can be fed to a pseudo random number generator.

### Usage with a prng

Required packages: 

- [rand](https://crates.io/crates/rand) 
- [rand_pcg](https://crates.io/crates/rand_pcg)

```rust
mod wasm4;

use rand::prelude::*;
use rand_pcg::Pcg64;

#[no_mangle]
fn update() {
    let rng = Pcg64::seed_from_u64(wasm4::seed());

    rng.gen_range(0..5); // returns a number between  0 included and 5 excluded

    rng.gen_range(0..=5); // returns a number between  0 included and 5 included
}

```


### Simple usage demo

![Nov-21-2021 10-49-52](https://user-images.githubusercontent.com/16583125/142757427-d1a3070e-3033-401b-8121-883e63247dc6.gif)

### Prng usage demo
![rand-Nov-21-2021 11-29-27](https://user-images.githubusercontent.com/16583125/142758357-3221fcf2-2e67-467c-9e47-d2698e8a5ca7.gif)


