### PR TITLE
Changed png2src template to mustache

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -83,6 +83,7 @@ program.command("png2src <images...>")
     .option("--rs, --rust", "Generate Rust source (Shorthand for --lang rs/--lang rust)")
     .option("--zig", "Generate Zig source (Shorthand for --lang zig)")
     .option("--t, --template <file>", "Template file with a custom output format")
+    .option("--output <file>", "File to write the result to", "-")
     .addOption(
         new Option("--lang <lang>", "Use the given language")
             .env("W4_LANG")

--- a/site/docs/guides/sprites.md
+++ b/site/docs/guides/sprites.md
@@ -261,20 +261,29 @@ from right to left: color 1 becomes 3, color 2 becomes 1, color 3 becomes 0 (tra
 You can use a custom template for generating a image source.
 Use a `--template filename` for this.
 
+Templates use the `Mustache` syntax. An array called `sprites` is provided.
+
 Basic template (C):
 ```
-#define %name%Width %width%
-#define %name%Height %height%
-#define %name%Flags %flagsHumanReadable%
-const uint8_t %name%[%length%] = { %bytes% };
+{{#sprites}}
+// {{name}}
+#define {{name}}Width {{width}}
+#define {{name}}Height {{height}}
+#define {{name}}Flags {{flagsHumanReadable}}
+const uint8_t {{name}}[{{length}}] = { {{bytes}} };
+
+{{/sprites}}
 ```
 
 Where:
-- `%name%` - filename (string),
-- `%idiomaticName%` - Rust specific variable name (string)
-- `%width%`, `%height%` - image dimensions (integer)
-- `%flags%`, `%flagsHumanReadable%` - type flag as integer and enum name (BLIT_2BPP or BLIT_1BPP)
-- `%length%` - count of bytes (integer)
-- `%bytes%` - comma separated series of bytes (string)
-- `%firstByte%` - first byte of the sprite (string)
-- `%restBytes%` - comma-separated series of bytes excluding the first one (string)
+- `{{#sprites}}`, `{{/sprites}}` - Start and end of the list of sprites
+- `{{name}}` - filename (i.e. `wallTop`; string),
+- `{{rustName}}` - Rust specific variable name (i.e. `WALL_TOP`; string)
+- `{{odinName}}` - Odin specific variable name (i.e. `wall_top`; string)
+- `{{odinFlags}}` - Odin specific flags (`nil` or `.USE_2BPP`)
+- `{{width}}`, `{{height}}` - image dimensions (integer)
+- `{{flags}}`, `{{flagsHumanReadable}}` - type flag as integer and enum name (BLIT_2BPP or BLIT_1BPP)
+- `{{length}}` - count of bytes (integer)
+- `{{bytes}}` - comma separated series of bytes (string)
+- `{{firstByte}}` - first byte of the sprite (string)
+- `{{restBytes}}` - comma-separated series of bytes excluding the first one (string)


### PR DESCRIPTION
For more complex templates it makes sense to use a more feature-rich
template engine.
Since mustache was already a dependency, I converted
all templates to mustache.

I've also added the ability to output directly to a file instead to
Stdout.