### PR TITLE
[zig]: support formatted strings

### DIFF
--- a/cli/assets/templates/zig/src/wasm4.zig
+++ b/cli/assets/templates/zig/src/wasm4.zig
@@ -69,7 +69,10 @@ pub extern fn oval(x: i32, y: i32, width: i32, height: i32) void;
 pub extern fn rect(x: i32, y: i32, width: u32, height: u32) void;
 
 /// Draws text using the built-in system font.
-pub extern fn text(str: [*:0]const u8, x: i32, y: i32) void;
+pub fn text(str: []const u8, x: i32, y: i32) void {
+    textUtf8(str.ptr, str.len, x, y);
+}
+extern fn textUtf8(strPtr: [*]const u8, strLen: usize, x: i32, y: i32) void;
 
 /// Draws a vertical line
 pub extern fn vline(x: i32, y: i32, len: u32) void;
@@ -114,4 +117,7 @@ pub extern fn diskw(src: [*]const u8, size: u32) u32;
 // └───────────────────────────────────────────────────────────────────────────┘
 
 /// Prints a message to the debug console.
-pub extern fn trace(x: [*:0]const u8) void;
+pub fn trace(x: []const u8) void {
+    traceUtf8(x.ptr, x.len);
+}
+extern fn traceUtf8(strPtr: [*]const u8, strLen: usize) void;


### PR DESCRIPTION
Support calling `text` and `trace` with non null-terminated strings, such
as formatted ones.

I'm bringing up this PR because I think this is an overlooked use case, but I could just be missing something.

While developing, there is inevitably a need to print formatted strings for debugging, so I've been using the `trace` API for this purpose. But the current version of `trace` in wasm4.zig wouldn't compile when passed formatted strings because they are not null-terminated.

Following is a demo of what I am trying to do and the compile error I get on main:

```zig
const std = @import("std");
const w4 = @import("wasm4.zig");

var buffer: [100]u8 = undefined;
var fba: std.heap.FixedBufferAllocator = undefined;
var allocator: *std.mem.Allocator = undefined;

export fn start() void {
    fba = std.heap.FixedBufferAllocator.init(&buffer);
    allocator = &fba.allocator;

    const n = 1;

    const msg = std.fmt.allocPrint(allocator, "n: {}", .{ n }) catch unreachable;
    defer allocator.free(msg);

    w4.trace(msg);

    // CURRENT main behavior:

    // w4.trace(msg);
    // error: expected type '[*:0]const u8', found '[]u8'

    // w4.trace(msg.ptr);
    // error: expected type '[*:0]const u8', found '[*]u8'
}

export fn update() void {
}
```