### PR TITLE
Stop when on trap instructions

### DIFF
--- a/runtimes/web/src/index.js
+++ b/runtimes/web/src/index.js
@@ -442,7 +442,6 @@ async function loadCartWasm () {
 
     function loop () {
         processGamepad();
-        requestAnimationFrame(loop);
 
         const now = performance.now();
         const deltaFrame = now - lastFrame;
@@ -455,6 +454,7 @@ async function loadCartWasm () {
                 ? "none" : "";
         }
 
+        requestAnimationFrame(loop);
     }
     loop();
 })();


### PR DESCRIPTION
I simply moved requestAnimationFrame to the end of the function. This
means the error will be encountered before the next frame is called.

Closes #196 