### PR TITLE
silenced "too many arguments" clippy lint

### DIFF
--- a/cli/assets/templates/rust/src/wasm4.rs
+++ b/cli/assets/templates/rust/src/wasm4.rs
@@ -59,6 +59,7 @@ extern "C" {
 }
 
 /// Copies a subregion within a larger sprite atlas to the framebuffer.
+#[allow(clippy::too_many_arguments)]
 pub fn blit_sub(
     sprite: &[u8],
     x: i32,


### PR DESCRIPTION
Hides a warning when running `cargo clippy` on a Rust WASM-4 project
```
warning: this function has too many arguments (9/7)
  --> src\wasm4.rs:62:1
   |
62 | / pub fn blit_sub(
63 | |     sprite: &[u8],
64 | |     x: i32,
65 | |     y: i32,
...  |
71 | |     flags: u32,
72 | | ) {
   | |__^
   |
   = note: `#[warn(clippy::too_many_arguments)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments
```