### PR TITLE
Fix Zig examples for snake tutorial

### DIFF
--- a/cli/lib/png2src.js
+++ b/cli/lib/png2src.js
@@ -87,9 +87,9 @@ const {{rustName}}: [u8; {{length}}] = [ {{bytes}} ];
     zig:
 `{{#sprites}}
 // {{name}}
-const {{name}}Width = {{width}};
-const {{name}}Height = {{height}};
-const {{name}}Flags = {{flags}}; // {{flagsHumanReadable}}
+const {{name}}_width = {{width}};
+const {{name}}_height = {{height}};
+const {{name}}_flags = {{flags}}; // {{flagsHumanReadable}}
 const {{name}} = [{{length}}]u8{ {{bytes}} };
 
 {{/sprites}}`,

--- a/site/docs/tutorials/snake/collision-detection.md
+++ b/site/docs/tutorials/snake/collision-detection.md
@@ -137,7 +137,7 @@ if (snake.body.get(0).equals(fruit)) {
 is enough already to check if the snake eats the fruit. And to make the snake "grow", simply increase the length of the snake using the `push` function of the array. Now it remains the question what values should this new piece have. The easiest would be to add the current last piece:
 
 ```zig
-var tail = snake.body.get(snake.body.len-1);
+const tail = snake.body.get(snake.body.len-1);
 snake.body.append(Point.init(tail.x, tail.y)) catch @panic("couldn't grow snake");
 ```
 
@@ -151,14 +151,14 @@ fruit.y = rnd(20);
 In it's final form, it could look like this:
 
 ```zig {4-9}
-    if (frameCount % 15 == 0) {
-        snake.update()
+    if (frame_count % 15 == 0) {
+        snake.update();
 
-        if (snake.body[0].equals(fruit)) {
-            let tail = snake.body[snake.body.length - 1]
-            snake.body.push(new Point(tail.x, tail.y))
-            fruit.x = rnd(20)
-            fruit.y = rnd(20)
+        if (snake.body.get(0).equals(fruit)) {
+            const tail = snake.body.get(snake.body.len - 1);
+            snake.body.append(Point.init(tail.x, tail.y)) catch @panic("couldn't grow snake");
+            fruit.x = rnd(20);
+            fruit.y = rnd(20);
         }
     }
 ```
@@ -296,18 +296,18 @@ What you do, is up to you. You could stop the game and show the score. Or you co
 Now you can call this function to check if the snake died in this frame:
 
 ```zig {4-6}
-    if (frameCount % 15 == 0) {
-        snake.update()
+    if (frame_count % 15 == 0) {
+        snake.update();
 
         if (snake.isDead()) {
             // Do something
         }
 
-        if (snake.body[0].equals(fruit)) {
-            let tail = snake.body[snake.body.length - 1]
-            snake.body.push(new Point(tail.x, tail.y))
-            fruit.x = rnd(20)
-            fruit.y = rnd(20)
+        if (snake.body.get(0).equals(fruit)) {
+            const tail = snake.body.get(snake.body.len - 1);
+            snake.body.append(Point.init(tail.x, tail.y)) catch @panic("couldn't grow snake");
+            fruit.x = rnd(20);
+            fruit.y = rnd(20);
         }
     }
 ```

--- a/site/docs/tutorials/snake/drawing-the-snake.md
+++ b/site/docs/tutorials/snake/drawing-the-snake.md
@@ -185,7 +185,7 @@ pub const Snake = struct {
 
     pub fn draw(this: @This()) void {
         for(this.body.constSlice()) |part| {
-            w4.rect(part.x * 8, part.y * 8, 8, 8));
+            w4.rect(part.x * 8, part.y * 8, 8, 8);
         }
     }
 }

--- a/site/docs/tutorials/snake/handling-user-input.md
+++ b/site/docs/tutorials/snake/handling-user-input.md
@@ -113,13 +113,13 @@ if justPressed&w4.BUTTON_UP != 0 {
 
 ```zig
 const gamepad = w4.GAMEPAD1.*;
-const justPressed = gamepad & (gamepad ^ prevState);
+const just_pressed = gamepad & (gamepad ^ prev_state);
 ```
 
-The constant `justPressed` now holds all buttons that were pressed this frame. You can check the state of a single button like this:
+The constant `just_pressed` now holds all buttons that were pressed this frame. You can check the state of a single button like this:
 
 ```zig
-if (justPressed & w4.BUTTON_UP != 0) {
+if (just_pressed & w4.BUTTON_UP != 0) {
     // Do something
 }
 ```
@@ -529,9 +529,9 @@ It's a good idea to handle the input in it's own function. Something like this c
 ```zig {1-8,13}
 fn input() void {
     const gamepad = w4.GAMEPAD1.*;
-    const justPressed = gamepad & (gamepad ^ prevState);
+    const just_pressed = gamepad & (gamepad ^ prevState);
 
-    if (justPressed & w4.BUTTON_UP != 0) {
+    if (just_pressed & w4.BUTTON_UP != 0) {
         // Do something
     }
 }
@@ -541,7 +541,7 @@ export fn update() void {
     
     input();
 
-    if (frameCount % 15 == 0) {
+    if (frame_count % 15 == 0) {
         snake.update();
     }
 
@@ -553,38 +553,38 @@ If you try to compile this, you should get an error: `error: use of undeclared i
 
 ```zig {3}
 var snake = Snake.init();
-var frameCount: u32 = 0;
-var prevState: u8 = 0;
+var frame_count: u32 = 0;
+var prev_state: u8 = 0;
 ```
 
 To notice any change in the gamepad, you have to store the *current state* at the end of the input. This will make it the *previous state*. And while you're at it, why not add the other 3 directions along the way:
 
 ```zig {8-18}
 function input(): void {
-    const gamepad = load<u8>(w4.GAMEPAD1)};
-    const justPressed = gamepad & (gamepad ^ prevState)
+    const gamepad = w4.GAMEPAD1.*;
+    const just_pressed = gamepad & (gamepad ^ prev_state)
 
-    if (justPressed & w4.BUTTON_LEFT != 0) {
+    if (just_pressed & w4.BUTTON_LEFT != 0) {
         // Do something
     }
-    if (justPressed & w4.BUTTON_RIGHT != 0) {
+    if (just_pressed & w4.BUTTON_RIGHT != 0) {
         // Do something
     }
-    if (justPressed & w4.BUTTON_UP != 0) {
+    if (just_pressed & w4.BUTTON_UP != 0) {
         // Do something
     }
-    if (justPressed & w4.BUTTON_DOWN != 0) {
+    if (just_pressed & w4.BUTTON_DOWN != 0) {
         w4.trace("down");
     }
 
-    prevState = gamepad
+    prev_state = gamepad;
 }
 ```
 
 If you want to check if it works: Use the `trace` function provided by WASM-4. Here's an example:
 
 ```zig
-    if (justPressed & w4.BUTTON_DOWN != 0) {
+    if (just_pressed & w4.BUTTON_DOWN != 0) {
         w4.trace("down");
     }
 ```
@@ -594,7 +594,7 @@ If you use `trace` in each if-statement, you should see the corresponding output
 Now, instead of using `trace` to confirm everything works as intended, you should replace it with something like this:
 
 ```zig
-    if (justPressed & w4.BUTTON_DOWN != 0) {
+    if (just_pressed & w4.BUTTON_DOWN != 0) {
         snake.down();
     }
 ```

--- a/site/docs/tutorials/snake/moving-the-snake.md
+++ b/site/docs/tutorials/snake/moving-the-snake.md
@@ -5,7 +5,7 @@ import MultiLanguage, {Page} from '@site/src/components/MultiLanguage';
 To move the snake, you have to change the X and Y position of every body-part of the snake.
 
 For this, you can start at the end of the body and give this part the values of the part ahead.
-Since the final piece to get's it's values "stolen" is the head, the head seems to disappear for very brief moment.
+Since the final piece to get its values "stolen" is the head, the head seems to disappear for very brief moment.
 
 After this is done, you simply move the head in the direction of the snake.
 Since all of this happens, before the snake is rendered, it appears as a fluid motion.
@@ -393,14 +393,14 @@ For this, you'd need a new variable. You can call it whatever you like, just be 
 
 ```zig {2}
 var snake: Snake = Snake.init();
-var frameCount: u32 = 0;
+var frame_count: u32 = 0;
 ```
 
 This variable in main.ts keeps track of all frames so far. Just increase it's value in the main-update function:
 
 ```zig {2}
 export fn update() void {
-    frameCount += 1;
+    frame_count += 1;
 
     snake.update();
 
@@ -413,9 +413,9 @@ Now all you need is to check if the passed frames are dividable by X:
 
 ```zig {4-6}
 export function update(): void {
-    frameCount++
+    frame_count += 1;
 
-    if (frameCount % 15 == 0) {
+    if (frame_count % 15 == 0) {
         snake.update()
     }
 

--- a/site/docs/tutorials/snake/placing-the-fruit.md
+++ b/site/docs/tutorials/snake/placing-the-fruit.md
@@ -70,8 +70,8 @@ const Point = @import("snake.zig").Point;
 
 var snake = Snake.init();
 var fruit: Point = undefined;
-var frameCount: u32 = 0;
-var prevState: u8 = 0;
+var frame_count: u32 = 0;
+var prev_state: u8 = 0;
 ```
 
 </Page>
@@ -180,7 +180,7 @@ Keep in mind, that the value of `rnd` is `nil` if it wasn't initialized yet.
 
 Zig's standard library has a couple of different random number generators, including some that are meant to be cryptographically secure. We don't need anything our snake game to be cryptographically secure, so we'll just use `std.rand.DefaultPrng`, where Prng means pseudo-random number generator. To start, we'll need to import `std` and initialize the prng:
 
-```zig {2,8-9,20-21}
+```zig {2,10-11,20-21}
 const w4 = @import("wasm4.zig");
 const std = @import("std");
 const Snake = @import("snake.zig").Snake;
@@ -188,9 +188,9 @@ const Point = @import("snake.zig").Point;
 
 var snake = Snake.init();
 var fruit: Point = undefined;
-var frameCount: u32 = 0;
-var prevState: u8 = 0;
-var prng = std.rand.DefaultPrng.init(0);
+var frame_count: u32 = 0;
+var prev_state: u8 = 0;
+var prng: std.rand.DefaultPrng = undefined;
 var random: std.rand.Random = undefined;
 
 export fn start() void {
@@ -208,13 +208,13 @@ export fn start() void {
 
 We can call `random.intRangeLessThan(T, at_least, less_than)` to get a number between `at_least` and `less_than`, with the type of `T`. You can wrap that in a helper function if you'd like:
 
-```zig 
+```zig
 fn rnd(max: i32) i32 {
-    random.intRangeLessThan(i32, 0, max);
+    return random.intRangeLessThan(i32, 0, max);
 }
 ```
 
-Now use it for the location of the fruit: 
+Now use it for the location of the fruit:
 
 ```zig {10}
 export fn start() void {
@@ -360,9 +360,9 @@ Now you need to import the image. For this, the WASM-4 CLI tool `w4` comes with 
 This will output the following content in the terminal:
 
 ```zig
-const fruitWidth = 8;
-const fruitHeight = 8;
-const fruitFlags = 1; // BLIT_2BPP
+const fruit_width = 8;
+const fruit_height = 8;
+const fruit_flags = 1; // BLIT_2BPP
 const fruit = [16]u8{ 0x00,0xa0,0x02,0x00,0x0e,0xf0,0x36,0x5c,0xd6,0x57,0xd5,0x57,0x35,0x5c,0x0f,0xf0 };
 ```
 
@@ -375,10 +375,10 @@ This will add the previous lines to your `main.zig` and causes an error because 
 ```zig {6}
 var snake = Snake.init();
 var fruit: Point = undefined;
-var frameCount: u32 = 0;
-var prevState: u8 = 0;
+var frame_count: u32 = 0;
+var prev_state: u8 = 0;
 var random: std.rand.Random = undefined;
-const fruitSprite = [16]u8{ 0x00,0xa0,0x02,0x00,0x0e,0xf0,0x36,0x5c,0xd6,0x57,0xd5,0x57,0x35,0x5c,0x0f,0xf0 };
+const fruit_sprite = [16]u8{ 0x00,0xa0,0x02,0x00,0x0e,0xf0,0x36,0x5c,0xd6,0x57,0xd5,0x57,0x35,0x5c,0x0f,0xf0 };
 ```
 
 With that out of the way, it's time to actually render the newly imported sprite.
@@ -514,16 +514,16 @@ In practice it looks like this:
 
 ```zig {11}
 export fn update() void {
-    frameCount += 1;
+    frame_count += 1;
 
     input();
 
-    if (frameCount % 15 == 0) {
+    if (frame_count % 15 == 0) {
         snake.update();
     }
     snake.draw();
 
-    w4.blit(fruitSprite, fruit.x * 8, fruit.y * 8, 8, 8, w4.BLIT_2BPP)
+    w4.blit(&fruit_sprite, fruit.x * 8, fruit.y * 8, 8, 8, w4.BLIT_2BPP);
 }
 ```
 
@@ -533,7 +533,7 @@ But since you set the drawing colors, you need to change the drawing colors too:
     snake.draw();
 
     w4.DRAW_COLORS.* = 0x4320;
-    w4.blit(&fruitSprite, fruit.x * 8, fruit.y * 8, 8, 8, w4.BLIT_2BPP);
+    w4.blit(&fruit_sprite, fruit.x * 8, fruit.y * 8, 8, 8, w4.BLIT_2BPP);
 ```
 
 This way, w4 uses the color palette in it's default configuration. Except for one thing: The background will be transparent.


### PR DESCRIPTION
- Fix Zig errors
- Adhere to Zig naming conventions https://ziglang.org/documentation/0.9.0/#Names
- Small typo in text