### PR TITLE
More flexible and fluid APU behaviour (web runtime APU)

### DIFF
--- a/runtimes/web/src/apu.js
+++ b/runtimes/web/src/apu.js
@@ -143,7 +143,9 @@ export class APU {
         node.connect(gain);
 
         const gainValue = gain.gain;
-        gainValue.setValueAtTime(0, 0);
+        if(existingNode == null){
+            gainValue.setValueAtTime(0, 0);
+        }
         gainValue.linearRampToValueAtTime(peakLevel, attackTime);
         gainValue.linearRampToValueAtTime(sustainLevel, decayTime);
         gainValue.linearRampToValueAtTime(sustainLevel, sustainTime);

--- a/runtimes/web/src/apu.js
+++ b/runtimes/web/src/apu.js
@@ -26,6 +26,7 @@ export class APU {
         this.ctx = ctx;
 
         this.nodes = new Array(4);
+        this.gains = new Array(4);
 
         function createDutyCycle (pulseWidth) {
             const real = new Float32Array(DUTY_CYCLE_LENGTH);
@@ -82,22 +83,31 @@ export class APU {
             sustainLevel *= 0.5;
         }
 
-        // Create gain node with ADSR ramp
-        const gain = ctx.createGain();
-        const gainValue = gain.gain;
-        gainValue.setValueAtTime(0, 0);
-        gainValue.linearRampToValueAtTime(peakLevel, attackTime);
-        gainValue.linearRampToValueAtTime(sustainLevel, decayTime);
-        gainValue.linearRampToValueAtTime(sustainLevel, sustainTime);
-        gainValue.linearRampToValueAtTime(0, releaseTime);
-
         let node;
-        if (channel == 3) {
-            node = ctx.createBufferSource();
-            node.buffer = this.noiseBuffer;
-            node.loop = true;
+        const existingNode = this.nodes[channel];
+        if (existingNode != null) {
+            node = existingNode;
+        } else {
+            // create a new node
+            if (channel == 3) {
+                node = ctx.createBufferSource();
+                node.buffer = this.noiseBuffer;
+                node.loop = true;
+            } else {
+                node = ctx.createOscillator();
+                if (channel == 2) {
+                    node.type = "triangle";
+                }
+            }
+            this.nodes[channel] = node;
+            node.addEventListener('ended', () => {this.nodes[channel] = null;}); //note: might want accesses to be atomic
+            node.start(0);
+        }
 
+        // update a node, whether new or reused
+        if (channel == 3) {
             const pbrValue = node.playbackRate;
+            pbrValue.cancelScheduledValues(0);
             pbrValue.setValueAtTime(freq1*freq1/1000000, 0);
             // pbrValue.value = NOISE_TABLE[16*(freq1/1024) | 0];
             if (freq2) {
@@ -105,30 +115,38 @@ export class APU {
             }
 
         } else {
-            node = ctx.createOscillator();
-            if (channel == 2) {
-                node.type = "triangle";
-            } else {
+            if (channel != 2) {
                 const wave = this.pulseDutyCycles[mode];
                 node.setPeriodicWave(wave);
             }
 
             const freqValue = node.frequency;
+            freqValue.cancelScheduledValues(0);
             freqValue.setValueAtTime(freq1, 0);
             if (freq2) {
                 freqValue.linearRampToValueAtTime(freq2, releaseTime);
             }
         }
+        node.stop(releaseTime); // replaces any previous stop delay
 
-        const existingNode = this.nodes[channel];
-        if (existingNode != null) {
-            existingNode.stop(0);
+        // Create gain node with ADSR ramp
+        let gain;
+        const existingGain = this.gains[channel];
+        if (existingGain != null) {
+            gain = existingGain;
+            existingGain.gain.cancelScheduledValues(0);
+        } else {
+            gain = ctx.createGain();
+            this.gains[channel] = gain;
+            gain.connect(ctx.destination);
         }
-        this.nodes[channel] = node;
-
-        node.start(0);
-        node.stop(releaseTime);
         node.connect(gain);
-        gain.connect(ctx.destination);
+
+        const gainValue = gain.gain;
+        gainValue.setValueAtTime(0, 0);
+        gainValue.linearRampToValueAtTime(peakLevel, attackTime);
+        gainValue.linearRampToValueAtTime(sustainLevel, decayTime);
+        gainValue.linearRampToValueAtTime(sustainLevel, sustainTime);
+        gainValue.linearRampToValueAtTime(0, releaseTime);
     }
 }


### PR DESCRIPTION
The first commit eliminates phase reset on `tone` calls if an audio channel stays in use.
Instead we only update tone properties, like time-to-release, the ADSR timings in the GainNode, and duty.

This basically merges overlapping tones, and allows for WAY smoother and more flexible audio processing.
You can test the difference in behaviour with this example program: [cart.zip](https://github.com/aduros/wasm4/files/7766442/cart.zip) Hold down X while switching through the different modes.
If you instead want the grating phase reset noise from before, you can still get that behaviour by inserting `tone` calls with duration 0 yourself.

The second commit is more subtle: If a channel was previously active, don't reset its initial gain to 0.
This allows smooth volume ramps between any two values by chaining `tone` calls with calculated parameters,
while previously you could only ever have a volume increase in the initial attack, always starting from 0.
Again, the old behaviour is still accessible to those who want it by inserting a `tone` call with volume 0 in between.

Side note: There is still a little bit of artifacting happening for me in the triangle channel - which I believe didn't (and still doesn't) occur without repeated calls to `tone`. I'm not sure why, and it's barely noticeable.

Also I'm not particularly well-versed in JavaScript. I believe the auto-deregistration on `ended` Event introduces a race condition, but I didn't feel like introducing atomics over it.

----

Feel free to reconsider/discuss these changes.
I really wanted this for my personal use case, and now that I've implemented it it looks like a clear improvement in all regards, but judge for yourself.

There's also the option to put it behind a system flag, now that I think about it, (suggested name `SYSTEM_MERGE_TONES`) which would make it 100% backwards compatible for all existing programs. (The code change this would require is trivial.)

EDIT: I forgot to test it for single-frame tones, there the channels don't hold over until the next frame.
A solution to that could be to define tone durations not as time but as number of frames, then wait until _after_ that next update call to see whether the channel was reused or should be stopped.
That would completely change the logic, and might not be worth it, just thinking out loud.