### PR TITLE
Nelua improvements

### DIFF
--- a/cli/assets/templates/nelua/src/main.nelua
+++ b/cli/assets/templates/nelua/src/main.nelua
@@ -1,25 +1,27 @@
 require "wasm4"
 
 local smiley: []uint8 = {
-    0b11000011,
-    0b10000001,
-    0b00100100,
-    0b00100100,
-    0b00000000,
-    0b00100100,
-    0b10011001,
-    0b11000011,
+  0b11000011,
+  0b10000001,
+  0b00100100,
+  0b00100100,
+  0b00000000,
+  0b00100100,
+  0b10011001,
+  0b11000011,
 };
 
-local function update(): void <cexport, codename "update">
-    $DRAW_COLORS = 2
-    text("Hello from Nelua!", 10, 10)
+local function update(): void
+  $DRAW_COLORS = 2
+  text("Hello from Nelua!", 10, 10)
 
-    local gamepad = $GAMEPAD1
-    if gamepad & BUTTON_1 ~= 0 then
-        $DRAW_COLORS = 4
-    end
+  local gamepad = $GAMEPAD1
+  if gamepad & BUTTON_1 ~= 0 then
+    $DRAW_COLORS = 4
+  end
 
-    blit(&smiley, 76, 76, 8, 8, BLIT_1BPP)
-    text("Press X to blink", 16, 90)
+  blit(&smiley, 76, 76, 8, 8, BLIT_1BPP)
+  text("Press X! to blink", 16, 90)
 end
+
+## setup_wasm4_callbacks(update)

--- a/cli/assets/templates/nelua/src/wasm4.nelua
+++ b/cli/assets/templates/nelua/src/wasm4.nelua
@@ -1,7 +1,28 @@
---
 -- WASM-4: https://wasm4.org/docs
 
-require "stringbuilder"
+-- Configure compiler.
+-- NOTE: This must come first because it changes some compiler settings!
+##[[
+ldflags "-Wl,-zstack-size=2048,--no-entry,--import-memory -mexec-model=reactor"
+ldflags "-Wl,--initial-memory=65536,--max-memory=65536,--global-base=6560,--export-dynamic"
+
+if DEBUG then
+  -- We should use at least 01 optimization, otherwise the application may use too much stack space.
+  cflags "-Oz -g"
+  ldflags "-Wl,--export-all,--no-gc-sections"
+else
+  -- Optimization for the making the application small as possible.
+  cflags "-Oz -g0 -flto"
+  ldflags "-Wl,--strip-all,--gc-sections,--lto-O3"
+end
+
+-- Generates an illegal instruction on aborts/panics
+context.rootpragmas.abort = "trap"
+-- We will not write to stdout, instead any write to it will be hooked.
+context.rootpragmas.writestderr = "hooked"
+-- We don't need to emit `main()` entry point, we will hook this ourselves.
+context.rootpragmas.nogcentry = true
+]]
 
 -- ┌───────────────────────────────────────────────────────────────────────────┐
 -- │                                                                           │
@@ -50,10 +71,10 @@ global SYSTEM_HIDE_GAMEPAD_OVERLAY <comptime> = 2
 -- └───────────────────────────────────────────────────────────────────────────┘
 
 -- Copies pixels to the framebuffer.
-global function blit(data: *[0]uint8 , x: int32, y: int32, width: uint32, height: uint32, flags: uint32): void <cimport> end
+global function blit(data: *[0]uint8, x: int32, y: int32, width: uint32, height: uint32, flags: uint32): void <cimport,cattribute'import_name("blit")'> end
 
 -- Copies a subregion within a larger sprite atlas to the framebuffer.
-global function blitSub(data: *[0]uint8, x: int32, y: int32, width: uint32, height: uint32, srcX: uint32, srcY: uint32, stride: uint32, flags: uint32): void <cimport> end
+global function blitSub(data: *[0]uint8, x: int32, y: int32, width: uint32, height: uint32, srcX: uint32, srcY: uint32, stride: uint32, flags: uint32): void <cimport,cattribute'import_name("blitSub")'> end
 
 global BLIT_2BPP <comptime> = 1
 global BLIT_1BPP <comptime> = 0
@@ -62,22 +83,22 @@ global BLIT_FLIP_Y <comptime> = 4
 global BLIT_ROTATE <comptime> = 8
 
 -- Draws a line between two points.
-global function line(x: int32, y: int32, width: uint32, height: uint32): void <cimport> end
+global function line(x: int32, y: int32, width: uint32, height: uint32): void <cimport,cattribute'import_name("line")'> end
 
 -- Draws a horizontal line.
-global function hline(x: int32, y: int32, len: uint32): void <cimport> end
+global function hline(x: int32, y: int32, len: uint32): void <cimport,cattribute'import_name("hline")'> end
 
 -- Draws a vertical line.
-global function vline(x: int32, y: int32, len: uint32): void <cimport> end
+global function vline(x: int32, y: int32, len: uint32): void <cimport,cattribute'import_name("vline")'> end
 
 -- Draws an oval (or circle).
-global function oval(x: int32, y: int32, width: uint32, height: uint32): void <cimport> end
+global function oval(x: int32, y: int32, width: uint32, height: uint32): void <cimport,cattribute'import_name("oval")'> end
 
 -- Draws a rectangle.
-global function rect(x: int32, y: int32, width: uint32, height: uint32): void <cimport> end
+global function rect(x: int32, y: int32, width: uint32, height: uint32): void <cimport,cattribute'import_name("rect")'> end
 
 -- Draws text using the built-in system font.
-global function text(str: cstring, x: int32, y: int32): void <cimport> end
+global function text(str: cstring, x: int32, y: int32): void <cimport,cattribute'import_name("text")'> end
 
 -- ┌───────────────────────────────────────────────────────────────────────────┐
 -- │                                                                           │
@@ -86,7 +107,7 @@ global function text(str: cstring, x: int32, y: int32): void <cimport> end
 -- └───────────────────────────────────────────────────────────────────────────┘
 
 -- Plays a sound tone.
-global function tone(frequency: uint32, duration: uint32, volume: uint32, flags: uint32): void <cimport> end
+global function tone(frequency: uint32, duration: uint32, volume: uint32, flags: uint32): void <cimport,cattribute'import_name("tone")'> end
 
 global TONE_PULSE1 <comptime> = 0
 global TONE_PULSE2 <comptime> = 1
@@ -104,46 +125,74 @@ global TONE_MODE4 <comptime> = 12
 -- └───────────────────────────────────────────────────────────────────────────┘
 
 -- Reads up to `size` bytes from persistent storage into the pointer `dest`.
-global function diskr(dest: pointer, size: uint32): uint32 <cimport> end
+global function diskr(dest: pointer, size: uint32): uint32 <cimport,cattribute'import_name("diskr")'> end
 
 -- Writes up to `size` bytes from the pointer `src` into persistent storage.
-global function diskw(src: pointer, size: uint32): uint32 <cimport> end
+global function diskw(src: pointer, size: uint32): uint32 <cimport,cattribute'import_name("diskw")'> end
+
+
+-- ┌───────────────────────────────────────────────────────────────────────────┐
+-- │                                                                           │
+-- │ Trace functions                                                           │
+-- │                                                                           │
+-- └───────────────────────────────────────────────────────────────────────────┘
 
 -- Prints a message to the debug console.
-global function trace(str: cstring): void <cimport> end
+global function trace(str: cstring): void <cimport,cattribute'import_name("trace")'> end
 
--- Hack to call Nelua initialization
-local function nelua_main(argc: integer, argv: integer): void <cimport, nodecl> end
-local function _start(): void <cexport, codename "_start">
-    nelua_main(0, 0)
-end
+-- Prints a message to the debug console (C style printf).
+global function tracef(format: cstring, ...: cvarargs): void <cimport,cattribute'import_name("tracef"),__format__ (__printf__, 1, 2)'> end
+
+-- ┌───────────────────────────────────────────────────────────────────────────┐
+-- │                                                                           │
+-- │ Nelua hooks and compiler configuration                                    │
+-- │                                                                           │
+-- └───────────────────────────────────────────────────────────────────────────┘
+
+## if not pragmas.nogc then
+require 'allocators.gc'
+## end
+
+require "stringbuilder" -- for `print()`
 
 -- Hook runtime errors to write using `trace()` instead of writing to C `stderr`.
 local function write_stderr(msg: cstring, len: usize, flush: boolean): void <codename "nelua_write_stderr">
-    trace(msg)
+  trace(msg)
 end
 
 -- Replace global print function to write using `trace()` instead of writing to C `stdout`.
 global function print(...: varargs)
-    local sb: stringbuilder <close>
-    ## for i=1,select('#', ...) do
-        ## if i > 1 then
-            sb:write('\t')
-        ## end
-        sb:write(#[select(i, ...)]#)
+  local sb: stringbuilder <close>
+  ## for i=1,select('#', ...) do
+    ## if i > 1 then
+      sb:write('\t')
     ## end
-    trace(sb:view())
+    sb:write(#[select(i, ...)]#)
+  ## end
+  trace(sb:view())
 end
 
--- Setup compiler settings
-##[[
-cflags "-Wl,-zstack-size=1024,--no-entry,--import-memory -mexec-model=reactor"
-cflags "-Wl,--initial-memory=65536,--max-memory=65536,--global-base=6560,--allow-undefined,--export-dynamic"
+-- Macro used to install `update` and `_start` WASM4 callbacks.
+## function setup_wasm4_callbacks(update)
+  ## static_assert(symbols.update, 'please declare update function!')
 
-if not DEBUG then
-    cflags "-Oz"
-end
+  local function _update(): void <cexport,codename'update'>
+    #[update]#()
+    ## if not pragmas.nogc then
+    -- We must always manually call garbage collection in the end of every frame.
+    -- This is the only safe point to do so, because in WASM we cannot scan the function stack.
+    gc:step()
+    ## end
+  end
 
-context.rootpragmas.abort = "trap"
-context.rootpragmas.writestderr = "hooked"
-]]
+  -- Hook application entry point.
+  local function _start(): void <entrypoint>
+    ## if not pragmas.nogc then
+    -- The GC should be initialized as the first thing.
+    gc:init(nilptr)
+    ## end
+    local function nelua_main(argc: cint, argv: *cstring): cint <cimport,nodecl> end
+    -- This will all code in top scopes.
+    nelua_main(0,nilptr)
+  end
+## end

--- a/cli/assets/templates/nelua/src/wasm4.nelua
+++ b/cli/assets/templates/nelua/src/wasm4.nelua
@@ -8,7 +8,7 @@ ldflags "-Wl,--initial-memory=65536,--max-memory=65536,--global-base=6560,--expo
 
 if DEBUG then
   -- We should use at least 01 optimization, otherwise the application may use too much stack space.
-  cflags "-Oz -g"
+  cflags "-O1 -g"
   ldflags "-Wl,--export-all,--no-gc-sections"
 else
   -- Optimization for the making the application small as possible.
@@ -22,6 +22,8 @@ context.rootpragmas.abort = "trap"
 context.rootpragmas.writestderr = "hooked"
 -- We don't need to emit `main()` entry point, we will hook this ourselves.
 context.rootpragmas.nogcentry = true
+-- Bundle `snprintf` (used by `string.format`).
+context.rootpragmas.usenanoprintf = true
 ]]
 
 -- ┌───────────────────────────────────────────────────────────────────────────┐
@@ -38,7 +40,7 @@ global SCREEN_SIZE <comptime> = 160
 -- │                                                                           │
 -- └───────────────────────────────────────────────────────────────────────────┘
 
-global PALETTE = (@*[4]uint32)(0x04)
+global PALETTE <comptime> = (@*[4]uint32)(0x04)
 global DRAW_COLORS <comptime> = (@*uint16)(0x14)
 global GAMEPAD1 <comptime> = (@*uint8)(0x16)
 global GAMEPAD2 <comptime> = (@*uint8)(0x17)
@@ -48,7 +50,7 @@ global MOUSE_X <comptime> = (@*int16)(0x1a)
 global MOUSE_Y <comptime> = (@*int16)(0x1c)
 global MOUSE_BUTTONS <comptime> = (@*uint8)(0x1e)
 global SYSTEM_FLAGS <comptime> = (@*uint8)(0x1f)
-global FRAMEBUFFER = (@*[6400]uint8)(0xa0)
+global FRAMEBUFFER <comptime> = (@*[6400]uint8)(0xa0)
 
 global BUTTON_1 <comptime> = 1
 global BUTTON_2 <comptime> = 2
@@ -174,7 +176,7 @@ end
 
 -- Macro used to install `update` and `_start` WASM4 callbacks.
 ## function setup_wasm4_callbacks(update)
-  ## static_assert(symbols.update, 'please declare update function!')
+  ## static_assert(update, 'please declare update function!')
 
   local function _update(): void <cexport,codename'update'>
     #[update]#()
@@ -186,7 +188,7 @@ end
   end
 
   -- Hook application entry point.
-  local function _start(): void <entrypoint>
+  local function _start(): void <cexport,entrypoint>
     ## if not pragmas.nogc then
     -- The GC should be initialized as the first thing.
     gc:init(nilptr)

--- a/cli/assets/templates/nelua/src/wasm4.nelua
+++ b/cli/assets/templates/nelua/src/wasm4.nelua
@@ -50,10 +50,10 @@ global SYSTEM_HIDE_GAMEPAD_OVERLAY <comptime> = 2
 -- └───────────────────────────────────────────────────────────────────────────┘
 
 -- Copies pixels to the framebuffer.
-global function blit(data: *uint8 <const> , x: int32, y: int32, width: uint32, height: uint32, flags: uint32): void <cimport> end
+global function blit(data: *[0]uint8 , x: int32, y: int32, width: uint32, height: uint32, flags: uint32): void <cimport> end
 
 -- Copies a subregion within a larger sprite atlas to the framebuffer.
-global function blitSub(data: *uint8 <const>, x: int32, y: int32, width: uint32, height: uint32, srcX: uint32, srcY: uint32, stride: uint32, flags: uint32): void <cimport> end
+global function blitSub(data: *[0]uint8, x: int32, y: int32, width: uint32, height: uint32, srcX: uint32, srcY: uint32, stride: uint32, flags: uint32): void <cimport> end
 
 global BLIT_2BPP <comptime> = 1
 global BLIT_1BPP <comptime> = 0
@@ -77,7 +77,7 @@ global function oval(x: int32, y: int32, width: uint32, height: uint32): void <c
 global function rect(x: int32, y: int32, width: uint32, height: uint32): void <cimport> end
 
 -- Draws text using the built-in system font.
-global function text(str: cstring <const>, x: int32, y: int32): void <cimport> end
+global function text(str: cstring, x: int32, y: int32): void <cimport> end
 
 -- ┌───────────────────────────────────────────────────────────────────────────┐
 -- │                                                                           │
@@ -104,13 +104,13 @@ global TONE_MODE4 <comptime> = 12
 -- └───────────────────────────────────────────────────────────────────────────┘
 
 -- Reads up to `size` bytes from persistent storage into the pointer `dest`.
-global function diskr(dest: *void, size: uint32): uint32 <cimport> end
+global function diskr(dest: pointer, size: uint32): uint32 <cimport> end
 
 -- Writes up to `size` bytes from the pointer `src` into persistent storage.
-global function diskw(src: *void <const>, size: uint32): uint32 <cimport> end
+global function diskw(src: pointer, size: uint32): uint32 <cimport> end
 
 -- Prints a message to the debug console.
-global function trace(str: cstring <const>): void <cimport> end
+global function trace(str: cstring): void <cimport> end
 
 -- Hack to call Nelua initialization
 local function nelua_main(argc: integer, argv: integer): void <cimport, nodecl> end

--- a/cli/lib/png2src.js
+++ b/cli/lib/png2src.js
@@ -47,9 +47,9 @@ var {{name}} = [{{length}}]byte { {{bytes}} }
     nelua:
 `{{#sprites}}
 -- {{name}}
-local {{name}}_width <const> = {{width}}
-local {{name}}_height <const> = {{height}}
-local {{name}}_flags <const> = {{flags}} -- {{flagsHumanReadable}}
+local {{name}}_width <comptime> = {{width}}
+local {{name}}_height <comptime> = {{height}}
+local {{name}}_flags <comptime> = {{flags}} -- {{flagsHumanReadable}}
 local {{name}}: [{{length}}]uint8 <const> = { {{bytes}} }
 
 {{/sprites}}`,

--- a/site/docs/getting-started/hello-world.md
+++ b/site/docs/getting-started/hello-world.md
@@ -44,9 +44,11 @@ func update () {
 ```lua
 require "wasm4"
 
-local function update () <cexport, codename "update">
+local function update ()
     rect(10, 10, 32, 32)
 end
+
+## setup_wasm4_callbacks(update)
 ```
 
 ```nim

--- a/site/docs/getting-started/hello-world.md
+++ b/site/docs/getting-started/hello-world.md
@@ -44,7 +44,7 @@ func update () {
 ```lua
 require "wasm4"
 
-local function update (): void <cexport, codename "update">
+local function update () <cexport, codename "update">
     rect(10, 10, 32, 32)
 end
 ```

--- a/site/docs/guides/audio.md
+++ b/site/docs/guides/audio.md
@@ -46,7 +46,7 @@ w4.Tone(262, 60, 100, w4.TONE_PULSE1)
 ```
 
 ```lua
--- TODO
+tone(262, 60, 100, TONE_PULSE1)
 ```
 
 ```nim
@@ -100,7 +100,7 @@ w4.Tone(262, 60, 100, w4.TONE_PULSE1 | w4.TONE_MODE3)
 ```
 
 ```lua
--- TODO
+tone(262, 60, 100, TONE_PULSE1 | TONE_MODE3)
 ```
 
 ```nim
@@ -148,7 +148,7 @@ w4.Tone(262 | (523 << 16), 60, 100, w4.TONE_PULSE1)
 ```
 
 ```lua
--- TODO
+tone(262 | (523 << 16), 60, 100, TONE_PULSE1)
 ```
 
 ```nim
@@ -205,7 +205,7 @@ w4.Tone(262, 60 | (30 << 8), 100, w4.TONE_PULSE1)
 ```
 
 ```lua
--- TODO
+tone(262, 60 | (30 << 8), 100, TONE_PULSE1)
 ```
 
 ```odin

--- a/site/docs/guides/basic-drawing.md
+++ b/site/docs/guides/basic-drawing.md
@@ -236,7 +236,8 @@ for i := range w4.FRAMEBUFFER {
 ```
 
 ```lua
--- TODO
+require 'memory'
+memory.set(FRAMEBUFFER, (3 | (3 << 2) | (3 << 4) | (3 << 6)), 160*160/4)
 ```
 
 ```nim
@@ -342,7 +343,20 @@ func pixel (x int, y int) {
 ```
 
 ```lua
--- TODO
+local function pixel(x: integer, y: integer)
+    -- The byte index into the framebuffer that contains (x, y)
+    local idx = (y*160 + x) >> 2
+
+    -- Calculate the bits within the byte that corresponds to our position
+    local shift = (x & 0b11) << 1
+    local mask = 0b11 << shift
+
+    -- Use the first DRAW_COLOR as the pixel color
+    local color = $DRAW_COLORS & 0b11
+
+    -- Write to the framebuffer
+    FRAMEBUFFER[idx] = (color << shift) | (FRAMEBUFFER[idx] & ~mask)
+end
 ```
 
 ```nim

--- a/site/docs/guides/basic-drawing.md
+++ b/site/docs/guides/basic-drawing.md
@@ -236,7 +236,7 @@ for i := range w4.FRAMEBUFFER {
 ```
 
 ```lua
-require 'memory'
+require "memory"
 memory.set(FRAMEBUFFER, (3 | (3 << 2) | (3 << 4) | (3 << 6)), 160*160/4)
 ```
 

--- a/site/docs/guides/saving-data.md
+++ b/site/docs/guides/saving-data.md
@@ -38,7 +38,8 @@ w4.DiskW(unsafe.Pointer(&gameData), unsafe.Sizeof(gameData))
 ```
 
 ```lua
--- TODO
+local game_data: integer = 1337
+diskw(&game_data, #@decltype(game_data))
 ```
 
 ```nim
@@ -102,7 +103,8 @@ w4.DiskR(unsafe.Pointer(&gameData), unsafe.Sizeof(gameData))
 ```
 
 ```lua
--- TODO
+local game_data: integer
+diskr(&game_data, #@decltype(game_data))
 ```
 
 ```nim

--- a/site/docs/guides/sprites.md
+++ b/site/docs/guides/sprites.md
@@ -73,7 +73,7 @@ var smiley = [8]byte {
 ```
 
 ```lua
-local smiley: []uint8 <const> = {
+local smiley: []uint8 = {
     0b11000011,
     0b10000001,
     0b00100100,

--- a/site/docs/guides/sprites.md
+++ b/site/docs/guides/sprites.md
@@ -73,7 +73,16 @@ var smiley = [8]byte {
 ```
 
 ```lua
--- TODO
+local smiley: []uint8 <const> = {
+    0b11000011,
+    0b10000001,
+    0b00100100,
+    0b00100100,
+    0b00000000,
+    0b00100100,
+    0b10011001,
+    0b11000011
+}
 ```
 
 ```nim
@@ -151,7 +160,7 @@ w4.Blit(&smiley[0], 10, 10, 8, 8, w4.BLIT_1BPP)
 ```
 
 ```lua
--- TODO
+blit(smiley, 10, 10, 8, 8, BLIT_1BPP)
 ```
 
 ```nim
@@ -200,7 +209,7 @@ w4.Blit(&smiley[0], 10, 10, 8, 8, w4.BLIT_1BPP | w4.BLIT_FLIP_Y)
 ```
 
 ```lua
--- TODO
+blit(smiley, 10, 10, 8, 8, BLIT_1BPP | BLIT_FLIP_Y)
 ```
 
 ```nim

--- a/site/docs/guides/user-input.md
+++ b/site/docs/guides/user-input.md
@@ -48,7 +48,11 @@ if gamepad&w4.BUTTON_RIGHT != 0 {
 ```
 
 ```lua
--- TODO
+local gamepad = $GAMEPAD1
+
+if gamepad & BUTTON_RIGHT ~= 0 then
+    trace("Right button is down!")
+end
 ```
 
 ```nim
@@ -172,7 +176,19 @@ func update () {
 ```
 
 ```lua
--- TODO
+local previous_gamepad: uint8
+
+local function update() <cexport, codename 'update'>
+    local gamepad = $GAMEPAD1
+
+    -- Only the buttons that were pressed down this frame
+    local pressed_this_frame = gamepad & (gamepad ~ previous_gamepad)
+    previous_gamepad = gamepad
+
+    if pressed_this_frame & BUTTON_RIGHT ~= 0 then
+        trace("Right button was just pressed!")
+    end
+end
 ```
 
 ```nim

--- a/site/docs/guides/user-input.md
+++ b/site/docs/guides/user-input.md
@@ -178,7 +178,7 @@ func update () {
 ```lua
 local previous_gamepad: uint8
 
-local function update() <cexport, codename 'update'>
+local function update()
     local gamepad = $GAMEPAD1
 
     -- Only the buttons that were pressed down this frame
@@ -189,6 +189,8 @@ local function update() <cexport, codename 'update'>
         trace("Right button was just pressed!")
     end
 end
+
+## setup_wasm4_callbacks(update)
 ```
 
 ```nim

--- a/site/docs/reference/cli.md
+++ b/site/docs/reference/cli.md
@@ -71,6 +71,7 @@ w4 init --lang nim
 | --c              |               | Uses C/C++  for the new project         |
 | --d              |               | Uses D for the new project              |
 | --go             |               | Uses Go for the new project             |
+| --nelua          |               | Uses Nelua for the new project          |
 | --nim            |               | Uses Nim for the new project            |
 | --odin           |               | Uses Odin for the new project           |
 | --rs             |               | Uses Rust for the new project           |
@@ -233,6 +234,7 @@ w4 png2src --lang rust top.png down.png left.png right.png
 | --c              |               | Uses C/C++  for the new project         |
 | --d              |               | Uses D for the new project              |
 | --go             |               | Uses Go for the new project             |
+| --nelua          |               | Uses Nelua for the new project          |
 | --nim            |               | Uses Nim for the new project            |
 | --odin           |               | Uses Odin for the new project           |
 | --rs             |               | Uses Rust for the new project           |

--- a/site/docs/tutorials/snake/collision-detection.md
+++ b/site/docs/tutorials/snake/collision-detection.md
@@ -313,7 +313,7 @@ What you do, is up to you. You could stop the game and show the score. Or you co
 
 ```lua
 function Snake:is_dead(): boolean
-  local head <const> = self.body[1]
+  local head = self.body[1]
 
   for i = 2, #self.body do
     if self.body[i] == head then

--- a/site/docs/tutorials/snake/collision-detection.md
+++ b/site/docs/tutorials/snake/collision-detection.md
@@ -106,6 +106,54 @@ Now you're almost done. Only "Game Over" is left to finish this game.
 
 </Page>
 
+<Page value="nelua">
+
+A simple
+
+```lua
+if snake.body[1] == fruit then
+  -- Snake's head hits the fruit
+end
+```
+
+is enough already to check if the snake eats the fruit. And to make the snake "grow", simply increase the length of the snake using the `push` function of the sequence. Now it remains the question what values should this new piece have. The easiest would be to add the current last piece:
+
+```lua
+local tail = snake.body[#snake.body]
+snake.body:push({ x = tail.x, y = tail.y })
+```
+
+Once this done, simply relocate the fruit:
+
+```lua
+fruit = { x = math.random(0, 19), y = math.random(0,19) }
+```
+
+Just this however will realocate the fruit in the same places for every run because it uses always the same seed, to generate a random seed we need to call `math.randomseed` function with at least one argument, which can be `frame_count`:
+
+```lua
+math.randomseed(frame_count)
+```
+
+In it's final form, it could look like this:
+
+```lua {4-9}
+  if frame_count % 15 == 0 then
+    snake:update()
+
+    if snake.body[1] == fruit then
+      local tail = snake.body[#snake.body]
+      snake.body:push({ x = tail.x, y = tail.y })
+      math.randomseed(frame_count)
+      fruit = { x = math.random(0, 19), y = math.random(0,19) }
+    end
+  end
+```
+
+Now you're almost done. Only "Game Over" is left to finish this game.
+
+</Page>
+
 <Page value="nim">
 
 // TODO
@@ -255,6 +303,45 @@ Now you can call this function to check if the snake died in this frame:
 			fruit.Y = rnd(20)
 		}
 	}
+```
+
+What you do, is up to you. You could stop the game and show the score. Or you could simply reset the game. Up to you.
+
+</Page>
+
+<Page value="nelua">
+
+```lua
+function Snake:is_dead(): boolean
+  local head <const> = self.body[1]
+
+  for i = 2, #self.body do
+    if self.body[i] == head then
+      return true
+    end
+  end
+
+  return false
+end
+```
+
+Now you can call this function to check if the snake died in this frame:
+
+```lua {4-6}
+  if frame_count % 15 == 0 then
+    snake:update()
+
+    if snake:is_dead() then
+      -- Do something
+    end
+
+    if snake.body[1] == fruit then
+      local tail = snake.body[#snake.body]
+      snake.body:push({ x = tail.x, y = tail.y })
+      math.randomseed(frame_count)
+      fruit = { x = math.random(0, 19), y = math.random(0,19) }
+    end
+  end
 ```
 
 What you do, is up to you. You could stop the game and show the score. Or you could simply reset the game. Up to you.

--- a/site/docs/tutorials/snake/creating-the-snake.md
+++ b/site/docs/tutorials/snake/creating-the-snake.md
@@ -106,10 +106,6 @@ local snake.Point = @record{
 
 local Point = snake.Point
 
-function Point.__eq(self: Point, other: Point): boolean
-  return self.x == other.x and self.y == other.y
-end
-
 local snake.Snake = @record{
   body: sequence(Point),
   direction: Point,

--- a/site/docs/tutorials/snake/creating-the-snake.md
+++ b/site/docs/tutorials/snake/creating-the-snake.md
@@ -84,6 +84,58 @@ Creating our own type reduces the size of the cart.
 
 </Page>
 
+<Page value="nelua">
+
+To keep things tidy, I recommend you'd create a new file called `snake.nelua`. This file contains two records:
+
+- The `Point` - Holding X and Y coordinates
+- The `Snake` - The actual snake implementation
+
+The content is rather simple:
+
+```lua
+require "wasm4"
+local sequence = require "sequence"
+
+local snake = @record{}
+
+local snake.Point = @record{
+  x: int32,
+  y: int32,
+}
+
+local Point = snake.Point
+
+function Point.__eq(self: Point, other: Point): boolean
+  return self.x == other.x and self.y == other.y
+end
+
+local snake.Snake = @record{
+  body: sequence(Point),
+  direction: Point,
+}
+
+local Snake = snake.Snake
+
+function Snake.init(): Snake
+  return Snake{
+    body = {
+      { x = 2, y = 0 },
+      { x = 1, y = 0 },
+      { x = 0, y = 0 },
+    },
+    direction = { x = 1, y = 0 },
+  }
+end
+
+return snake
+```
+
+The snake record contains the body and the current direction of the snake instance.
+But it lacks any functionality for now.
+
+</Page>
+
 <Page value="nim">
 
 // TODO

--- a/site/docs/tutorials/snake/drawing-the-snake.md
+++ b/site/docs/tutorials/snake/drawing-the-snake.md
@@ -173,16 +173,14 @@ require "wasm4"
 local Snake = require "snake"
 local Point, Snake = Snake.Point, Snake.Snake
 
-local snake <const> = Snake.init()
+local snake = Snake.init()
 
-local function start() <cexport, codename "start">
-  $PALETTE = {
-    0xfbf7f3,
-    0xe5b083,
-    0x426e5d,
-    0x20283d
-  }
-end
+$PALETTE = {
+  0xfbf7f3,
+  0xe5b083,
+  0x426e5d,
+  0x20283d
+}
 
 local function update()
   snake:draw()

--- a/site/docs/tutorials/snake/drawing-the-snake.md
+++ b/site/docs/tutorials/snake/drawing-the-snake.md
@@ -144,6 +144,63 @@ You should see some green blocks at the top.
 
 </Page>
 
+<Page value="nelua">
+
+To draw the snake, you can take advantage of nelua's `for` syntax.
+To make it a little easier, it's a good idea to use the `rect` function of WASM-4:
+
+```lua
+// rect draws a rectangle. It uses color 1 to fill and color 2 for the outline
+global function rect(x: int32, y: int32, width: uint32, height: uint32)
+```
+
+With that out the way, let's see what a first draft could look like.
+
+```lua
+function Snake:draw()
+  for i = 1, #self.body do
+    rect(self.body[i].x * 8, self.body[i].y * 8, 8, 8)
+  end
+end
+```
+
+Simply loop through the body and draw it at `x * 8` and `y * 8`. 8 is the width and the height of a single part. On a 160x160 screen, it's big enough to fit snake that is 20*20=400 parts long.
+
+That's all fine, but since we haven't initialized the snake, nothing can be drawn. To fix this, simply create a new variable in main and call it's draw function:
+
+```lua {2-5, 17}
+require "wasm4"
+local Snake = require "snake"
+local Point, Snake = Snake.Point, Snake.Snake
+
+local snake <const> = Snake.init()
+
+local function start() <cexport, codename "start">
+  $PALETTE = {
+    0xfbf7f3,
+    0xe5b083,
+    0x426e5d,
+    0x20283d
+  }
+end
+
+local function update()
+  snake:draw()
+end
+
+## setup_wasm4_callbacks(update)
+```
+
+Creating a global variable of a snake with some default values.
+
+After that, simply call the `draw` function of the snake.
+
+You should see some green blocks at the top.
+
+![Snake Body](images/draw-body.webp)
+
+</Page>
+
 <Page value="nim">
 
 // TODO
@@ -390,6 +447,87 @@ func (s *Snake) Draw() {
 	*w4.DRAW_COLORS = 0x0004
 	w4.Rect(s.Body[0].X*8, s.Body[0].Y*8, 8, 8)
 }
+```
+
+This changes the color back and adds the darker green as it's outline.
+
+![Snake with outline](images/draw-body-3.webp)
+
+</Page>
+
+<Page value="nelua">
+
+But where is the head? You can pick a side. Either position `[1]` or position `[#self.body]`.
+
+I think it's easier to pick `[1]`.
+
+Since the body is drawn, head is not much of a problem. Simply use the `rect` function again. But use a specific part instead:
+
+```lua
+  rect(self.body[1].x * 8, self.body[1].y * 8, 8, 8)
+```
+
+The draw function should now look like this:
+
+```lua {7}
+function Snake:draw()
+  for i = 1, #self.body do
+    rect(self.body[i].x * 8, self.body[i].y * 8, 8, 8)
+  end
+
+  rect(self.body[1].x * 8, self.body[1].y * 8, 8, 8)
+end
+```
+
+Notice the difference? Me neither.
+
+The head should stand out a little. For this, you can use a different color:
+
+```lua
+$DRAW_COLORS = 0x0004;
+```
+
+You can set the colors with this variable. You can look at this variable like a table that is read from right to left.
+
+The value for each digit can be  0 up to 4:
+
+- 0 = Use transparency
+- 1 = Use the 1st color from the color palette
+- 2 = Use the 2nd color from the color palette
+- 3 = Use the 3rd color from the color palette
+- 4 = Use the 4th color from the color palette
+
+The snippet above reads like this: "Color 1 uses Color 4 of the color palette, Color 2 to Color 4 don't use any color." The basic drawing functions use "Color 1" to fill the shape and "Color 2" for the border.
+
+If you change the source to
+
+```lua {7}
+function Snake:draw()
+  for i = 1, #self.body do
+    rect(self.body[i].x * 8, self.body[i].y * 8, 8, 8)
+  end
+
+  $DRAW_COLORS = 0x0004;
+  rect(self.body[1].x * 8, self.body[1].y * 8, 8, 8)
+end
+```
+
+Result:
+
+![Changing Color](images/draw-body-2.webp)
+
+You'll see a change. The snake changed color. Not only the head, but the complete snake! Once you've set a color, it stays that way. So if you want to change only the head, you have to change Color 1 again. Right before you draw the body.
+
+```lua {2}
+function Snake:draw()
+  $DRAW_COLORS = 0x0043;
+  for i = 1, #self.body do
+    rect(self.body[i].x * 8, self.body[i].y * 8, 8, 8)
+  end
+
+  $DRAW_COLORS = 0x0004;
+  rect(self.body[1].x * 8, self.body[1].y * 8, 8, 8)
+end
 ```
 
 This changes the color back and adds the darker green as it's outline.

--- a/site/docs/tutorials/snake/handling-user-input.md
+++ b/site/docs/tutorials/snake/handling-user-input.md
@@ -94,8 +94,8 @@ if justPressed&w4.BUTTON_UP != 0 {
 <Page value="nelua">
 
 ```lua
-local gamepad <const> = $GAMEPAD1
-local just_pressed <const> = gamepad & (gamepad ~ prev_state)
+local gamepad = $GAMEPAD1
+local just_pressed = gamepad & (gamepad ~ prev_state)
 ```
 
 The constant `just_pressed` now holds all buttons that were pressed this frame. You can check the state of a single button like this:
@@ -567,7 +567,7 @@ end
 If you try to compile this, you should get an error: `error: undeclared symbol 'prev_state'`. This is easily fixed. Just place the prev_state into the var-section:
 
 ```lua {3}
-local snake <const> = Snake.init()
+local snake = Snake.init()
 local frame_count = 0
 local prev_state = 0
 ```

--- a/site/docs/tutorials/snake/moving-the-snake.md
+++ b/site/docs/tutorials/snake/moving-the-snake.md
@@ -423,7 +423,7 @@ That's it. Your snake should be quite a bit slower now. This reduces the snake f
 For this, you'd need a new variable. You can call it whatever you like, just be sure you know what it's purpose is.
 
 ```lua {2}
-local snake <const> = Snake.init()
+local snake = Snake.init()
 local frame_count = 0
 ```
 

--- a/site/docs/tutorials/snake/moving-the-snake.md
+++ b/site/docs/tutorials/snake/moving-the-snake.md
@@ -92,6 +92,32 @@ Now if you execute this, you'd notice that you can't see much. In fact, you migh
 
 </Page>
 
+<Page value="nelua">
+To achieve the first step (moving the body, excluding the head), a simple loop is all you need:
+
+```lua
+function Snake:update()
+  for i = #self.body, 2, -1 do
+    self.body[i] = self.body[i - 1]
+  end
+end
+```
+
+Don't forget to call the new function in the main-loop:
+
+```lua {2}
+local function update()
+  snake:update()
+  snake:draw()
+end
+```
+
+Now if you execute this, you'd notice that you can't see much. In fact, you might see the snake for a short moment before the head is all that's left.
+
+![](images/snake_move_head_only.webp)
+
+</Page>
+
 <Page value="nim">
 
 // TODO
@@ -202,6 +228,30 @@ func (s *Snake) Update() {
 		s.Body[0].Y = 19
 	}
 }
+```
+
+</Page>
+
+<Page value="nelua">
+
+This isn't hard either. Simple add the add the direction to the current head. And then make sure the head stays within the boundaries:
+
+```lua {6-14}
+function Snake:update()
+  for i = #self.body, 2, -1 do
+    self.body[i] = self.body[i - 1]
+  end
+
+  self.body[1].x = (self.body[1].x + self.direction.x) % 20
+  self.body[1].y = (self.body[1].y + self.direction.y) % 20
+
+  if self.body[1].x < 0 then
+    self.body[1].x = 19
+  end
+  if self.body[1].y < 0 then
+    self.body[1].y = 19
+  end
+end
 ```
 
 </Page>
@@ -360,6 +410,45 @@ func update() {
 
 	snake.Draw()
 }
+```
+
+That's it. Your snake should be quite a bit slower now. This reduces the snake from 60 units per second to 4 units per second (60/15 = 4).
+
+![Moving Snake (slow)](images/snake-motion-slow.webp)
+
+</Page>
+
+<Page value="nelua">
+
+For this, you'd need a new variable. You can call it whatever you like, just be sure you know what it's purpose is.
+
+```lua {2}
+local snake <const> = Snake.init()
+local frame_count = 0
+```
+
+This variable in main.nelua keeps track of all frames so far. Just increase it's value in the main-update function:
+
+```lua {2}
+local function update()
+  frame_count = frame_count + 1
+  snake:update()
+  snake:draw()
+end
+```
+
+Now all you need is to check if the passed frames are dividable by X:
+
+```lua {4-6}
+local function update()
+  frame_count = frame_count + 1
+
+  if frame_count % 15 == 0 then
+    snake:update()
+  end
+
+  snake:draw()
+end
 ```
 
 That's it. Your snake should be quite a bit slower now. This reduces the snake from 60 units per second to 4 units per second (60/15 = 4).

--- a/site/docs/tutorials/snake/placing-the-fruit.md
+++ b/site/docs/tutorials/snake/placing-the-fruit.md
@@ -50,7 +50,7 @@ require "wasm4"
 local Snake = require "snake"
 local Point, Snake = Snake.Point, Snake.Snake
 
-local snake <const> = Snake.init()
+local snake = Snake.init()
 local fruit: Point
 local frame_count = 0
 local prev_state = 0
@@ -182,7 +182,7 @@ This allows you to call `math.random(0, 19)` to get a number between `0` and `19
 ```lua {1, 4}
 local math = require 'math'
 
-local snake <const> = Snake.init()
+local snake = Snake.init()
 local fruit: Point = { x = math.random(0, 19), y = math.random(0,19) }
 local frame_count = 0
 local prev_state = 0
@@ -378,21 +378,21 @@ This will output the following content in the terminal:
 local fruit_width <comptime> = 8
 local fruit_height <comptime> = 8
 local fruit_flags <comptime> = 1 -- BLIT_2BPP
-local fruit: [16]uint8 <const> = { 0x00,0xa0,0x02,0x00,0x0e,0xf0,0x36,0x5c,0xd6,0x57,0xd5,0x57,0x35,0x5c,0x0f,0xf0 }
+local fruit: [16]uint8 = { 0x00,0xa0,0x02,0x00,0x0e,0xf0,0x36,0x5c,0xd6,0x57,0xd5,0x57,0x35,0x5c,0x0f,0xf0 }
 ```
 
 To get it into a an existing file, use the `>>` operator. Like this:
 
-`w4 png2src --assemblyscript fruit.png >> main.nelua`
+`w4 png2src --nelua fruit.png >> main.nelua`
 
 This will add the previous lines to your `main.nelua` and it will shadow the previous `fruit` variable. Just rename the new fruit to `fruit_sprite` and move it somewhere else. Also: You can remove the other stuff added, you won't need it for this project:
 
 ```lua {5}
-local snake <const> = Snake.init()
+local snake = Snake.init()
 local fruit: Point = { x = math.random(0, 19), y = math.random(0,19) }
 local frame_count = 0
 local prev_state = 0
-local fruit_sprite: [16]uint8 <const> = { 0x00,0xa0,0x02,0x00,0x0e,0xf0,0x36,0x5c,0xd6,0x57,0xd5,0x57,0x35,0x5c,0x0f,0xf0 }
+local fruit_sprite: [16]uint8 = { 0x00,0xa0,0x02,0x00,0x0e,0xf0,0x36,0x5c,0xd6,0x57,0xd5,0x57,0x35,0x5c,0x0f,0xf0 }
 ```
 
 With that out of the way, it's time to actually render the newly imported sprite.

--- a/site/docs/tutorials/snake/publish-your-game.md
+++ b/site/docs/tutorials/snake/publish-your-game.md
@@ -48,6 +48,16 @@ Your game will be here: `build/cart.wasm`
 
 </Page>
 
+<Page value="nelua">
+
+```shell
+make
+```
+
+Your game will be here: `build/cart.wasm`
+
+</Page>
+
 <Page value="nim">
 
 // TODO

--- a/site/docs/tutorials/snake/setting-color-palette.md
+++ b/site/docs/tutorials/snake/setting-color-palette.md
@@ -61,6 +61,15 @@ func update() {
 }
 ```
 
+```lua
+require "wasm4"
+
+local function update()
+end
+
+## setup_wasm4_callbacks(update)
+```
+
 ```nim
 # TODO
 ```
@@ -112,6 +121,17 @@ func start() {
 	w4.PALETTE[2] = 0x426e5d
 	w4.PALETTE[3] = 0x20283d
 }
+```
+
+```lua
+local function start() <cexport, codename "start">
+  $PALETTE = {
+    0xfbf7f3,
+    0xe5b083,
+    0x426e5d,
+    0x20283d
+  }
+end
 ```
 
 ```nim

--- a/site/docs/tutorials/snake/setting-color-palette.md
+++ b/site/docs/tutorials/snake/setting-color-palette.md
@@ -124,14 +124,15 @@ func start() {
 ```
 
 ```lua
-local function start() <cexport, codename "start">
-  $PALETTE = {
-    0xfbf7f3,
-    0xe5b083,
-    0x426e5d,
-    0x20283d
-  }
-end
+require "wasm4"
+
+-- in nelua we can place the "start" code at the top of the file
+$PALETTE = {
+  0xfbf7f3,
+  0xe5b083,
+  0x426e5d,
+  0x20283d
+}
 ```
 
 ```nim

--- a/site/docs/tutorials/snake/setup-project.md
+++ b/site/docs/tutorials/snake/setup-project.md
@@ -122,6 +122,29 @@ w4 watch
 
 </Page>
 
+<Page value="nelua">
+
+To compile Nelua projects you will need `nelua` installed.
+
+```shell
+w4 new --nelua snake
+cd snake
+```
+
+Compile the .wasm cartridge:
+
+```shell
+make
+```
+
+Run it in WASM-4 with:
+
+```shell
+w4 watch
+```
+
+</Page>
+
 <Page value="nim">
 
 :::note Work in Progress


### PR DESCRIPTION
This PR improves the nelua bindings and add the remaining documentation for the website, it's related with #204 

However, I also have a question, the bindings uses [`<comptime>` annotations](https://nelua.io/overview/#compile-time-variables), like this:
```lua
global MOUSE_LEFT <comptime> = 1
global MOUSE_RIGHT <comptime> = 2
global MOUSE_MIDDLE <comptime> = 4
```
This way, the nelua compiler generates more efficient code.

My question is, should `png2src` also emit `<comptime>` constants instead of run-time ones? Like this:
```lua
local bunny_width <comptime> = 16
local bunny_height <comptime> = 16
local bunny_flags <comptime> = 1 -- BLIT_2BPP
local bunny: [64]uint8 <const> = { --[[...]] }
```

If so, I can commit and add this change in this PR if you wish.