### PR TITLE
fix blit for non-byte-aligned sprites

### DIFF
--- a/runtimes/native/src/framebuffer.c
+++ b/runtimes/native/src/framebuffer.c
@@ -348,14 +348,15 @@ void w4_framebufferBlit (const uint8_t* sprite, int dstX, int dstY, int width, i
             // Sample the sprite to get a color index
             int colorIdx;
             int x = srcX + sx, y = srcY + sy;
+            int bitIndex = y * srcStride + x;
             if (bpp2) {
-                uint8_t byte = sprite[(y * srcStride + x) >> 2];
-                int shift = 6 - ((x & 0x03) << 1);
+                uint8_t byte = sprite[bitIndex >> 2];
+                int shift = 6 - ((bitIndex & 0x03) << 1);
                 colorIdx = (byte >> shift) & 0b11;
 
             } else {
-                uint8_t byte = sprite[(y * srcStride + x) >> 3];
-                int shift = 7 - (x & 0x07);
+                uint8_t byte = sprite[bitIndex >> 3];
+                int shift = 7 - (bitIndex & 0x07);
                 colorIdx = (byte >> shift) & 0b1;
             }
 

--- a/runtimes/web/src/framebuffer.js
+++ b/runtimes/web/src/framebuffer.js
@@ -334,14 +334,15 @@ export class Framebuffer {
                 // Sample the sprite to get a color index
                 let colorIdx;
                 const x = srcX + sx, y = srcY + sy;
+                const bitIndex = y * srcStride + x;
                 if (bpp2) {
-                    const byte = sprite[(y * srcStride + x) >>> 2];
-                    const shift = 6 - ((x & 0x03) << 1);
+                    const byte = sprite[bitIndex >>> 2];
+                    const shift = 6 - ((bitIndex & 0x03) << 1);
                     colorIdx = (byte >>> shift) & 0b11;
 
                 } else {
-                    const byte = sprite[(y * srcStride + x) >>> 3];
-                    const shift = 7 - (x & 0x07);
+                    const byte = sprite[bitIndex >>> 3];
+                    const shift = 7 - (bitIndex & 0x7);
                     colorIdx = (byte >>> shift) & 0b1;
                 }
 


### PR DESCRIPTION
After investigating #228 I found that `x` was used to calculate the `shift`. I believe that using the `bitIndex` instead should result in the actual expected behavior. 

- [x] fix in web runtime
- [x] fix in native runtime