### PR TITLE
[Docs][Wasm4] optionally set initial language of MultiLanguageCode from query params

### DIFF
--- a/site/src/components/MultiLanguage.js
+++ b/site/src/components/MultiLanguage.js
@@ -1,4 +1,4 @@
-import React, {useState, cloneElement, Children, useRef, useEffect } from 'react';
+import React, {useState, cloneElement, Children, useRef, useEffect, useLayoutEffect } from 'react';
 import Link from '@docusaurus/Link';
 import { useHistory } from 'react-router-dom';
 import clsx from 'clsx';
@@ -71,7 +71,7 @@ function useLanguageCode() {
     const search = (typeof window !== 'undefined' ? window.location.search : '');
     const rawLanguagePreference = tabGroupChoices.language;
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         const langFromPreferences = normalizeLanguageValue(rawLanguagePreference);
 
         if(isValidLanguageValue(langFromPreferences)) {

--- a/site/src/components/MultiLanguageCode.js
+++ b/site/src/components/MultiLanguageCode.js
@@ -17,8 +17,8 @@ const classNameToLanguage = {
 };
 
 export default function MultiLanguageCode (props) {
-    const pages = props.children.map(child => (
-        <Page value={classNameToLanguage[child.props.children.props.className]}>
+    const pages = props.children.map((child, idx) => (
+        <Page key={idx} value={classNameToLanguage[child.props.children.props.className]}>
             {child}
         </Page>
     ));


### PR DESCRIPTION
This PR adds the option to set the initial language from query params, param `code-lang`, and fixes several react related issues in `MultiLanguage.js` & `MultiLanguageCode.js`

example: https://deploy-preview-243--wasm4.netlify.app/docs/guides/saving-data/?code-lang=go#reading-data-from-disk