### PR TITLE
(enh) add blue screen for WASM Runtime errors

### DIFF
--- a/runtimes/web/src/constants.js
+++ b/runtimes/web/src/constants.js
@@ -7,6 +7,8 @@ export const HEIGHT = 160;
 
 export const STORAGE_SIZE = 1024;
 
+export const CRASH_TITLE = "WASM-4";
+
 // Default palette
 export const COLORS = [
     0xe0f8cf,

--- a/runtimes/web/src/index.js
+++ b/runtimes/web/src/index.js
@@ -473,7 +473,9 @@ async function loadCartWasm () {
 
         if (deltaFrame >= INTERVAL) {
             lastFrame = now - (deltaFrame % INTERVAL);
-            runtime.update();
+            if (!runtime.crashed) {
+                runtime.update();
+            }
 
             gamepadOverlay.style.display = runtime.getSystemFlag(constants.SYSTEM_HIDE_GAMEPAD_OVERLAY)
                 ? "none" : "";


### PR DESCRIPTION
Adds blue screen error handling for common WASM Runtime errors.

Resolves #245 

- [x] web runtime
- [x] <del>native runtime</del> not necessary per @aduros 

![Screen Shot 2021-12-27 at 8 35 10 AM](https://user-images.githubusercontent.com/6473/147478557-b7895ea4-cc0a-42e3-be8f-152473834b0a.png)
![Screen Shot 2021-12-27 at 9 07 01 AM](https://user-images.githubusercontent.com/6473/147479266-f3069113-6d35-4d98-a143-c8501ef5c58d.png)

