### PR TITLE
zig template: export only the 'start' and 'update' functions

### DIFF
--- a/cli/assets/templates/zig/build.zig
+++ b/cli/assets/templates/zig/build.zig
@@ -11,5 +11,9 @@ pub fn build(b: *std.build.Builder) void {
     lib.max_memory = 65536;
     lib.global_base = 6560;
     lib.stack_size = 8192;
+    // Workaround https://github.com/ziglang/zig/issues/2910, preventing
+    // functions from compiler_rt getting incorrectly marked as exported, which
+    // prevents them from being removed even if unused.
+    lib.export_symbol_names = &[_][]const u8{ "start", "update" };
     lib.install();
 }


### PR DESCRIPTION
Workaround for https://github.com/ziglang/zig/issues/2910.

See in particular:
https://github.com/ziglang/zig/issues/2910#issuecomment-1003455815
https://github.com/ziglang/zig/issues/2910#issuecomment-1003456922