### PR TITLE
Use packed structs rather than bit manipulations in zig

### DIFF
--- a/cli/assets/templates/zig/src/wasm4.zig
+++ b/cli/assets/templates/zig/src/wasm4.zig
@@ -86,17 +86,56 @@ pub extern fn hline(x: i32, y: i32, len: u32) void;
 // │                                                                           │
 // └───────────────────────────────────────────────────────────────────────────┘
 
-/// Plays a sound tone.
-pub extern fn tone(frequency: u32, duration: u32, volume: u32, flags: u32) void;
+const externs = struct {
+    extern fn tone(frequency: u32, duration: u32, volume: u32, flags: u32) void;
+};
 
-pub const TONE_PULSE1: u32 = 0;
-pub const TONE_PULSE2: u32 = 1;
-pub const TONE_TRIANGLE: u32 = 2;
-pub const TONE_NOISE: u32 = 3;
-pub const TONE_MODE1: u32 = 0;
-pub const TONE_MODE2: u32 = 4;
-pub const TONE_MODE3: u32 = 8;
-pub const TONE_MODE4: u32 = 12;
+/// Plays a sound tone.
+pub fn tone(frequency: ToneFrequency, duration: ToneDuration, volume: u32, flags: ToneFlags) void {
+    return externs.tone(@bitCast(u32, frequency), @bitCast(u32, duration), volume, @bitCast(u8, flags));
+}
+pub const ToneFrequency = packed struct {
+    start: u16,
+    end: u16 = 0,
+
+    comptime {
+        if(@sizeOf(@This()) != @sizeOf(u32)) unreachable;
+    }
+};
+
+pub const ToneDuration = packed struct {
+    sustain: u8,
+    release: u8 = 0,
+    decay: u8 = 0,
+    attack: u8 = 0,
+
+    comptime {
+        if(@sizeOf(@This()) != @sizeOf(u32)) unreachable;
+    }
+};
+
+pub const ToneFlags = packed struct {
+    pub const Channel = enum(u2) {
+        pulse1,
+        pulse2,
+        triangle,
+        noise,
+    };
+    pub const Mode = enum(u2) {
+        p12_5,
+        p25,
+        p50,
+        p75,
+    };
+
+    channel: Channel,
+    mode: Mode = .p12_5,
+    _: u4 = 0,
+
+    comptime {
+        if(@sizeOf(@This()) != @sizeOf(u8)) unreachable;
+    }
+};
 
 // ┌───────────────────────────────────────────────────────────────────────────┐
 // │                                                                           │

--- a/cli/assets/templates/zig/src/wasm4.zig
+++ b/cli/assets/templates/zig/src/wasm4.zig
@@ -17,26 +17,67 @@ pub const CANVAS_SIZE: u32 = 160;
 
 pub const PALETTE: *[4]u32 = @intToPtr(*[4]u32, 0x04);
 pub const DRAW_COLORS: *u16 = @intToPtr(*u16, 0x14);
-pub const GAMEPAD1: *const u8 = @intToPtr(*const u8, 0x16);
-pub const GAMEPAD2: *const u8 = @intToPtr(*const u8, 0x17);
-pub const GAMEPAD3: *const u8 = @intToPtr(*const u8, 0x18);
-pub const GAMEPAD4: *const u8 = @intToPtr(*const u8, 0x19);
-pub const MOUSE_X: *const i16 = @intToPtr(*const i16, 0x1a);
-pub const MOUSE_Y: *const i16 = @intToPtr(*const i16, 0x1c);
-pub const MOUSE_BUTTONS: *const u8 = @intToPtr(*const u8, 0x1e);
-pub const SYSTEM_FLAGS: *u8 = @intToPtr(*u8, 0x1f);
+pub const GAMEPAD1: *const Gamepad = @intToPtr(*const Gamepad, 0x16);
+pub const GAMEPAD2: *const Gamepad = @intToPtr(*const Gamepad, 0x17);
+pub const GAMEPAD3: *const Gamepad = @intToPtr(*const Gamepad, 0x18);
+pub const GAMEPAD4: *const Gamepad = @intToPtr(*const Gamepad, 0x19);
+
+pub const MOUSE: *const Mouse = @intToPtr(*const Mouse, 0x1a);
+pub const SYSTEM_FLAGS: *SystemFlags = @intToPtr(*SystemFlags, 0x1f);
 pub const FRAMEBUFFER: *[6400]u8 = @intToPtr(*[6400]u8, 0xA0);
 
-pub const BUTTON_1: u8 = 1;
-pub const BUTTON_2: u8 = 2;
-pub const BUTTON_LEFT: u8 = 16;
-pub const BUTTON_RIGHT: u8 = 32;
-pub const BUTTON_UP: u8 = 64;
-pub const BUTTON_DOWN: u8 = 128;
+pub const Gamepad = packed struct {
+    button_1: bool,
+    button_2: bool,
+    _: u2 = 0,
+    button_left: bool,
+    button_right: bool,
+    button_up: bool,
+    button_down: bool,
+    comptime {
+        if(@sizeOf(@This()) != @sizeOf(u8)) unreachable;
+    }
 
-pub const MOUSE_LEFT: u8 = 1;
-pub const MOUSE_RIGHT: u8 = 2;
-pub const MOUSE_MIDDLE: u8 = 4;
+    pub fn format(value: @This(), comptime _: []const u8, _: @import("std").fmt.FormatOptions, writer: anytype) !void {
+        if(value.button_1) try writer.writeAll("1");
+        if(value.button_2) try writer.writeAll("2");
+        if(value.button_left) try writer.writeAll("<");//"←");
+        if(value.button_right) try writer.writeAll(">");
+        if(value.button_up) try writer.writeAll("^");
+        if(value.button_down) try writer.writeAll("v");
+    }
+};
+
+pub const Mouse = packed struct {
+    x: i16,
+    y: i16,
+    buttons: MouseButtons,
+    pub fn pos(mouse: Mouse) Vec2 {
+        return .{mouse.x, mouse.y};
+    }
+    comptime {
+        if(@sizeOf(@This()) != 5) unreachable;
+    }
+};
+
+pub const MouseButtons = packed struct {
+    left: bool,
+    right: bool,
+    middle: bool,
+    _: u5 = 0,
+    comptime {
+        if(@sizeOf(@This()) != @sizeOf(u8)) unreachable;
+    }
+};
+
+pub const SystemFlags = packed struct {
+    preserve_framebuffer: bool,
+    hide_gamepad_overlay: bool,
+    _: u6 = 0,
+    comptime {
+        if(@sizeOf(@This()) != @sizeOf(u8)) unreachable;
+    }
+};
 
 pub const SYSTEM_PRESERVE_FRAMEBUFFER: u8 = 1;
 pub const SYSTEM_HIDE_GAMEPAD_OVERLAY: u8 = 2;

--- a/site/docs/guides/audio.md
+++ b/site/docs/guides/audio.md
@@ -68,7 +68,7 @@ tone(262, 60, 100, TONE_PULSE1);
 ```
 
 ```zig
-w4.tone(262, 60, 100, w4.TONE_PULSE1);
+w4.tone(.{ .start = 262 }, .{ .sustain = 60 }, 100, .{ .channel = .pulse1 });
 ```
 
 </MultiLanguageCode>
@@ -132,7 +132,7 @@ tone(262, 60, 100, TONE_PULSE1 | TONE_MODE3);
 ```
 
 ```zig
-w4.tone(262, 60, 100, w4.TONE_PULSE1 | w4.TONE_MODE3);
+w4.tone(.{ .start = 262 }, .{ .sustain = 60 }, 100, .{ .channel = .pulse1, .mode = .p50 });
 ```
 
 </MultiLanguageCode>
@@ -190,7 +190,7 @@ tone(262 | (523 << 16), 60, 100, TONE_PULSE1);
 ```
 
 ```zig
-w4.tone(262 | (523 << 16), 60, 100, w4.TONE_PULSE1);
+w4.tone(.{ .start = 262, .end = 523 }, .{ .sustain = 60 }, 100, .{ .channel = .pulse1 });
 ```
 
 </MultiLanguageCode>
@@ -255,7 +255,7 @@ tone(262, 60 | (30 << 8), 100, TONE_PULSE1);
 ```
 
 ```zig
-w4.tone(262, 60 | (30 << 8), 100, w4.TONE_PULSE1);
+w4.tone(.{ .start = 262 }, .{ .sustain = 60, .release = 30 }, 100, .{ .channel = .pulse1 });
 ```
 
 </MultiLanguageCode>

--- a/site/docs/guides/user-input.md
+++ b/site/docs/guides/user-input.md
@@ -92,7 +92,7 @@ if gamepad & BUTTON_RIGHT != 0 {
 ```zig
 const gamepad = w4.GAMEPAD1.*;
 
-if (gamepad & w4.BUTTON_RIGHT != 0) {
+if (gamepad.button_right) {
     w4.trace("Right button is down!");
 }
 ```
@@ -289,15 +289,17 @@ fn update() {
 ```
 
 ```zig
-var previous_gamepad: u8 = 0;
+var previous_gamepad: w4.Gamepad = @bitCast(w4.Gamepad, @as(u8, 0));
 
 export fn update() void {
     const gamepad = w4.GAMEPAD1.*;
 
-    const pressed_this_frame = gamepad & (gamepad ^ previous_gamepad);
+    const pressed_this_frame = @bitCast(w4.Gamepad,
+        @bitCast(u8, gamepad) & (@bitCast(u8, gamepad) ^ @bitCast(u8, previous_gamepad))
+    );
     previous_gamepad = gamepad;
 
-    if (pressed_this_frame & w4.BUTTON_RIGHT != 0) {
+    if (pressed_this_frame.button_right) {
         w4.trace("Right button was just pressed!");
     }
 }


### PR DESCRIPTION
This

- makes it nicer to write code for wasm4 in zig

but also

- makes the language template more complicated (122 lines → 202 lines, now defines some structs and is no longer just a bunch of extern fns)
- makes zig examples different from examples in other languages, making it harder to update documentation.

While I'm personally using this in my project, I'm not sure if this would be good as the default template or not.

This lets you do:

```zig
    if(w4.MOUSE.buttons.left) {
```

instead of

```zig
    if(w4.MOUSE & w4.MOUSE_LEFT != 0) {
```

and it lets you write

```zig
w4.tone(
    .{ .start = 262, .end = 523 },
    .{ .sustain = 60, .release = 30 },
    100,
    .{ .channel = .pulse1, .mode = .p50 },
);
```

instead of

```zig
w4.tone(
    262 | (523 << 16),
    60 | (30 << 8),
    100,
    w4.TONE_PULSE1 | w4.TONE_MODE3,
);
```