### PR TITLE
Replaced the `which` command with the `command -v` for locating `wasm-opt` in the Makefile templates

### DIFF
--- a/cli/assets/templates/c/Makefile
+++ b/cli/assets/templates/c/Makefile
@@ -47,7 +47,7 @@ all: build/cart.wasm
 build/cart.wasm: $(OBJECTS)
 	$(CXX) -o $@ $(OBJECTS) $(LDFLAGS)
 ifneq ($(DEBUG), 1)
-ifeq (, $(shell which $(WASM_OPT)))
+ifeq (, $(shell command -v $(WASM_OPT)))
 	@echo Tip: $(WASM_OPT) was not found. Install it from binaryen for smaller builds!
 else
 	$(WASM_OPT) $(WASM_OPT_FLAGS) $@ -o $@

--- a/cli/assets/templates/go/Makefile
+++ b/cli/assets/templates/go/Makefile
@@ -20,7 +20,7 @@ all:
 	@mkdir -p build
 	$(GO) build $(GOFLAGS) -o build/cart.wasm .
 ifneq ($(DEBUG), 1)
-ifeq (, $(shell which $(WASM_OPT)))
+ifeq (, $(shell command -v $(WASM_OPT)))
 	@echo Tip: $(WASM_OPT) was not found. Install it from binaryen for smaller builds!
 else
 	$(WASM_OPT) $(WASM_OPT_FLAGS) build/cart.wasm -o build/cart.wasm

--- a/cli/assets/templates/nelua/Makefile
+++ b/cli/assets/templates/nelua/Makefile
@@ -24,7 +24,7 @@ all:
 	@mkdir -p build
 	$(NELUA) $(NELUA_FLAGS) src/main.nelua --output build/cart.wasm
 ifneq ($(DEBUG), 1)
-ifeq (, $(shell which $(WASM_OPT)))
+ifeq (, $(shell command -v $(WASM_OPT)))
 	@echo Tip: $(WASM_OPT) was not found. Install it from binaryen for smaller builds!
 else
 	$(WASM_OPT) $(WASM_OPT_FLAGS) build/cart.wasm -o build/cart.wasm

--- a/cli/assets/templates/wat/Makefile
+++ b/cli/assets/templates/wat/Makefile
@@ -24,7 +24,7 @@ build/cart.wasm: main.wat
 	@$(MKDIR) build
 	$(WAT2WASM) $< -o $@
 ifneq ($(DEBUG), 1)
-ifeq (, $(shell which $(WASM_OPT)))
+ifeq (, $(shell command -v $(WASM_OPT)))
 	@echo Tip: $(WASM_OPT) was not found. Install it from binaryen for smaller builds!
 else
 	$(WASM_OPT) $(WASM_OPT_FLAGS) $@ -o $@


### PR DESCRIPTION
If `which` cannot find the `wasm-opt` file it outputs an error message, which contains a full `PATH` printed.
It creates a lot of noise for the `make` command. The `command -v` does not print anything if the file is not found.