### PR TITLE
Added error check for LinkError in safeCall

### DIFF
--- a/runtimes/web/src/runtime.js
+++ b/runtimes/web/src/runtime.js
@@ -162,7 +162,8 @@ export class Runtime {
             try {
                 await fn();
             } catch (err) {
-                if (err instanceof WebAssembly.RuntimeError) {
+                if (err instanceof WebAssembly.RuntimeError 
+                    || err instanceof WebAssembly.LinkError) {
                     this.blueScreen(err);
                 } else {
                     // if we don't know what it is, throw it again


### PR DESCRIPTION
Fix for issue #272
Added check for an instance of the WebAssembly.LinkError in safeCalll, which in turn shows blue screen
 