### PR TITLE
Avoid calling update while we're resetting the game

### DIFF
--- a/runtimes/web/src/constants.js
+++ b/runtimes/web/src/constants.js
@@ -274,3 +274,9 @@ export const FONT = Uint8Array.of(
 );
 
 export const showDevToolsQueryKey = 'devtools-open';
+
+export const pauseFlags = {
+    unfocused: 1,
+    crashed: 2,
+    rebooting: 4
+}

--- a/runtimes/web/src/index.js
+++ b/runtimes/web/src/index.js
@@ -99,8 +99,12 @@ async function loadCartWasm () {
 
     async function reboot () {
         runtime.reset(true);
+        // By indicating that the runtime has crashed,
+        // we avoid calling update until we're done rebooting
+        runtime.crashed = true;
         await runtime.load(wasmBuffer);
         runtime.start();
+        runtime.crashed = false;
     }
 
     function takeScreenshot () {
@@ -461,7 +465,7 @@ async function loadCartWasm () {
     window.addEventListener("pointermove", onPointerEvent);
     window.addEventListener("pointerup", onPointerEvent);
 
-    const gamepadOverlay = document.getElementById("gamepad"); 
+    const gamepadOverlay = document.getElementById("gamepad");
     // https://gist.github.com/addyosmani/5434533#file-limitloop-js-L60
 
     const INTERVAL = 1000 / 60;
@@ -485,7 +489,7 @@ async function loadCartWasm () {
                 ? "none" : "";
 
             if (DEVELOPER_BUILD) {
-                devtoolsManager.updateCompleted(runtime.data, deltaFrame);  
+                devtoolsManager.updateCompleted(runtime.data, deltaFrame);
             }
         }
 

--- a/runtimes/web/src/index.js
+++ b/runtimes/web/src/index.js
@@ -99,12 +99,10 @@ async function loadCartWasm () {
 
     async function reboot () {
         runtime.reset(true);
-        // By indicating that the runtime has crashed,
-        // we avoid calling update until we're done rebooting
-        runtime.crashed = true;
+        runtime.pauseState |= constants.pauseFlags.rebooting;
         await runtime.load(wasmBuffer);
         runtime.start();
-        runtime.crashed = false;
+        runtime.pauseState &= ~constants.pauseFlags.rebooting;
     }
 
     function takeScreenshot () {
@@ -481,9 +479,7 @@ async function loadCartWasm () {
 
         if (deltaFrame >= INTERVAL) {
             lastFrame = now - (deltaFrame % INTERVAL);
-            if (!runtime.crashed) {
-                runtime.update();
-            }
+            runtime.update();
 
             gamepadOverlay.style.display = runtime.getSystemFlag(constants.SYSTEM_HIDE_GAMEPAD_OVERLAY)
                 ? "none" : "";

--- a/runtimes/web/src/runtime.js
+++ b/runtimes/web/src/runtime.js
@@ -372,7 +372,7 @@ export class Runtime {
         this.paused = !document.body.classList.contains('focus');
 
         if(this.paused) {
-           this.pauseAudio();
+            this.pauseAudio();
         } else {
             this.unlockAudio();
         }

--- a/runtimes/web/src/runtime.js
+++ b/runtimes/web/src/runtime.js
@@ -28,8 +28,7 @@ export class Runtime {
 
         this.reset();
 
-        this.paused = false;
-        this.crashed = false;
+        this.pauseState = 0;
     }
 
     setMouse (x, y, buttons) {
@@ -93,7 +92,7 @@ export class Runtime {
         if (zeroMemory) {
             mem32.fill(0);
         }
-        this.crashed = false;
+        this.pauseState &= ~constants.pauseFlags.crashed;
         mem32.set(constants.COLORS, constants.ADDR_PALETTE >> 2);
         this.data.setUint16(constants.ADDR_DRAW_COLORS, 0x1203, true);
 
@@ -313,7 +312,7 @@ export class Runtime {
     }
 
     update () {
-        if (this.paused) {
+        if (this.pauseState > 0) {
             return;
         }
 
@@ -327,7 +326,7 @@ export class Runtime {
     }
 
     blueScreen(err) {
-        this.crashed = true;
+        this.pauseState |= constants.pauseFlags.crashed;
 
         const COLORS = [
             0x1111ee, // blue
@@ -369,12 +368,14 @@ export class Runtime {
     }
 
     updateIdleState = () => {
-        this.paused = !document.body.classList.contains('focus');
+        const lostFocus = !document.body.classList.contains('focus');
 
-        if(this.paused) {
+        if (lostFocus) {
             this.pauseAudio();
+            this.pauseState |= constants.pauseFlags.unfocused;
         } else {
             this.unlockAudio();
+            this.pauseState &= ~constants.pauseFlags.unfocused;
         }
     }
 }


### PR DESCRIPTION
This PR fixes #273 by setting "crashed" to true after resetting the runtime. This causes the runtime not to update while the new WASM is being initialized, as per my theory in #273. Experimentally, this seems to resolve the issue.

This approach feels a little hacky, as we're semantically overloading the meaning of the "crashed" field to also mean "rebooting". Setting "paused" to true would not be as reliable, because other events on the page could still seemingly cause the runtime to unpause while it's still not ready.

A potential alternative would be to have reboot create a new runtime from scratch, avoiding any possibility of the active runtime being in an intermediate state. That may be the best approach, but I didn't implement that as it would be more refactoring and I was curious what your thoughts were @aduros 