### PR TITLE
Add instructions for building specific targets

### DIFF
--- a/runtimes/native/README.md
+++ b/runtimes/native/README.md
@@ -26,3 +26,10 @@ Running:
 ```
 
 For release builds, pass `-DCMAKE_BUILD_TYPE=Release` to cmake.
+
+If you want to build only one target:
+
+``` shell
+cmake --build build --target wasm4_libretro
+cmake --build build --target wasm4
+```


### PR DESCRIPTION
This is probably common knowledge but I wanted to build only one of the targets and began by modifying the CMakeLists.txt, but then figured out I could just add a command line flag and thought others might want to know.

In other news, I got WASM4 working on my RG351: 
![mpv-shot0003](https://user-images.githubusercontent.com/10042482/148884961-028d4ee4-e07f-4aad-bd3e-1dd560e20035.jpg)