### PR TITLE
Allow recording of videos at any duration

### DIFF
--- a/runtimes/web/src/index.js
+++ b/runtimes/web/src/index.js
@@ -121,8 +121,11 @@ async function loadCartWasm () {
 
     let videoRecorder = null;
     function recordVideo () {
-        if (videoRecorder != null) {
-            return; // Still recording, ignore
+        if (videoRecorder != null) { // Stops recording after hitting the record key during recording
+            videoRecorder.requestData();
+            videoRecorder.stop();
+            videoRecorder = null;
+            return;
         }
 
         const mimeType = "video/webm";
@@ -148,11 +151,7 @@ async function loadCartWasm () {
         };
 
         videoRecorder.start();
-        setTimeout(() => {
-            videoRecorder.requestData();
-            videoRecorder.stop();
-            videoRecorder = null;
-        }, 4000);
+        
     }
 
     let savedState = null;


### PR DESCRIPTION
Changed the recordVideo function so that instead of pressing record and then recording for 4 seconds, gameplay starts being recorded upon pressing record until pressing it again