### PR TITLE
Updated devtools/web-devtools folder name

### DIFF
--- a/devtools/web/README.md
+++ b/devtools/web/README.md
@@ -33,7 +33,7 @@ All exported components can be customized using the following css variables:
 ### Install dependencies
 
 ```bash
-npm --prefix devtools/web-devtools i
+npm --prefix devtools/web i
 ```
 
 This package relies on [lit](https://lit.dev) library to manage custom elements:
@@ -44,25 +44,25 @@ docs are available [here](https://lit.dev/docs/).
 Starts local server
 
 ```bash
-npm --prefix devtools/web-devtools run dev
+npm --prefix devtools/web run dev
 ```
 
 ### Build package & web runtime
 
 ```bash
-npm --prefix devtools/web-devtools/ run build && npm --prefix runtimes/web/ run build
+npm --prefix devtools/web/ run build && npm --prefix runtimes/web/ run build
 ```
 
 ### Build package
 
 ```bash
-npm --prefix devtools/web-devtools run build
+npm --prefix devtools/web run build
 ```
 
 ### Run formatter
 
 ```bash
-npm --prefix devtools/web-devtools run prettify
+npm --prefix devtools/web run prettify
 ```
 
 ## License


### PR DESCRIPTION
devtools/web-devtools was renamed to devtools/web in 6d0f4a856b0d371bcf213a23796a57bf3a3bfb05, but devtools/web/README.md still used the old folder name in every command