### PR TITLE
fix devtools fps counter

### DIFF
--- a/runtimes/web/src/index.js
+++ b/runtimes/web/src/index.js
@@ -487,7 +487,7 @@ async function loadCartWasm () {
         const deltaFrame = now - lastFrame;
 
         if (deltaFrame >= INTERVAL) {
-            lastFrame = now - (deltaFrame % INTERVAL);
+            lastFrame = now;
             runtime.update();
 
             gamepadOverlay.style.display = runtime.getSystemFlag(constants.SYSTEM_HIDE_GAMEPAD_OVERLAY)

--- a/runtimes/web/src/index.js
+++ b/runtimes/web/src/index.js
@@ -477,24 +477,28 @@ async function loadCartWasm () {
 
     const INTERVAL = 1000 / 60;
 
-    // lastFrame is not a real time, it has frame-gap correction
     let lastFrame = performance.now();
+
+    // used for keeping a consistent framerate. not a real time.
+    let lastFrameGapCorrected = lastFrame;
 
     function loop () {
         processGamepad();
 
         const now = performance.now();
-        const deltaFrame = now - lastFrame;
+        const deltaFrameGapCorrected = now - lastFrameGapCorrected;
 
-        if (deltaFrame >= INTERVAL) {
+        if (deltaFrameGapCorrected >= INTERVAL) {
+            const deltaTime = now - lastFrame;
             lastFrame = now;
+            lastFrameGapCorrected = now - (deltaFrameGapCorrected % INTERVAL);
             runtime.update();
 
             gamepadOverlay.style.display = runtime.getSystemFlag(constants.SYSTEM_HIDE_GAMEPAD_OVERLAY)
                 ? "none" : "";
 
             if (DEVELOPER_BUILD) {
-                devtoolsManager.updateCompleted(runtime.data, deltaFrame);
+                devtoolsManager.updateCompleted(runtime.data, deltaTime);
             }
         }
 


### PR DESCRIPTION
deltaFrame was being used for the fps counter, but it is inaccurate because it does not reflect a real time. this caused the frame counter to display ~40-45fps when the actual framerate was 60fps