### PR TITLE
png2src: Readd support for indexed PNG ordering

### DIFF
--- a/cli/lib/png2src.js
+++ b/cli/lib/png2src.js
@@ -124,7 +124,7 @@ function run(sourceFile) {
     let colorCount = 0;
     if (png.palette) {
         colorCount = png.palette.length;
-        if (colorCount >= 4) {
+        if (colorCount > 4) {
             throw new Error('Indexed PNG has too many colors: maximum is 4.');
         }
         for (let i = 0; i < colorCount; ++i) {


### PR DESCRIPTION
I was scratching my head a bit at why I couldn't manually order the palette in a png and then use png2src (since I could do so before!) After looking at the code, I noticed that functionality had been lost in #293.

This PR changes so when a png has an indexed palette, it will use that order, otherwise it will proceed to use the algorithm implemented in #293. 
