### PR TITLE
Add support for saving/loading disks to native runtime

### DIFF
--- a/runtimes/native/src/backend/main.c
+++ b/runtimes/native/src/backend/main.c
@@ -105,6 +105,18 @@ static void saveDiskFile (const w4_Disk* disk, const char *diskPath) {
     }
 }
 
+static void trimFileExtension (char *path) {
+    size_t len = strlen(path);
+    while (len--) {
+        if (path[len] == '.') {
+            path[len] = 0; // Set null terminator
+            return;
+        } else if (path[len] == '/' || path[len] == '\\') {
+            return;
+        }
+    }
+}
+
 int main (int argc, const char* argv[]) {
     uint8_t* cartBytes;
     size_t cartLength;
@@ -135,6 +147,9 @@ int main (int argc, const char* argv[]) {
         // Look for disk file
         diskPath = malloc(strlen(argv[0]) + sizeof(DISK_FILE_EXT));
         strcpy(diskPath, argv[0]);
+#ifdef _WIN32
+        trimFileExtension(diskPath); // Trim .exe on Windows
+#endif
         strcat(diskPath, DISK_FILE_EXT);
         loadDiskFile(&disk, diskPath);
     } else {

--- a/runtimes/native/src/backend/main.c
+++ b/runtimes/native/src/backend/main.c
@@ -162,7 +162,7 @@ int main (int argc, const char* argv[]) {
     audioInit();
 
     uint8_t* memory = w4_wasmInit();
-    w4_runtimeInit(memory, (uint8_t*)&disk);
+    w4_runtimeInit(memory, &disk);
 
     w4_wasmLoadModule(cartBytes, cartLength);
 

--- a/runtimes/native/src/backend/main.c
+++ b/runtimes/native/src/backend/main.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <cubeb/cubeb.h>
 
@@ -11,6 +12,8 @@
 #if defined(_WIN32)
 #include <windows.h>
 #endif
+
+#define DISK_FILE_EXT ".disk"
 
 typedef struct {
     // Should be the 4 byte ASCII string "CART" (1414676803)
@@ -78,10 +81,36 @@ static void audioUninit () {
 #endif
 }
 
+static void loadDiskFile (w4_Disk* disk, const char *diskPath) {
+    FILE *file = fopen(diskPath, "rb");
+    if (file) {
+        fseek(file, 0, SEEK_END);
+        uint16_t saveSz = ftell(file);
+        fseek(file, 0, SEEK_SET);
+        if (saveSz > sizeof(disk->data)) {
+            saveSz = sizeof(disk->data);
+        }
+        disk->size = fread(disk->data, 1, saveSz, file);
+        fclose(file);
+    }
+}
+
+static void saveDiskFile (const w4_Disk* disk, const char *diskPath) {
+    if (disk->size) {
+        FILE* file = fopen(diskPath, "wb");
+        fwrite(disk->data, 1, disk->size, file);
+        fclose(file);
+    } else {
+        remove(diskPath);
+    }
+}
+
 int main (int argc, const char* argv[]) {
     uint8_t* cartBytes;
     size_t cartLength;
+    w4_Disk disk = {0};
     const char* title = "WASM-4";
+    char* diskPath = NULL;
 
     if (argc < 2) {
         FILE* file = fopen(argv[0], "rb");
@@ -103,6 +132,11 @@ int main (int argc, const char* argv[]) {
         cartLength = fread(cartBytes, 1, footer.cartLength, file);
         fclose(file);
 
+        // Look for disk file
+        diskPath = malloc(strlen(argv[0]) + sizeof(DISK_FILE_EXT));
+        strcpy(diskPath, argv[0]);
+        strcat(diskPath, DISK_FILE_EXT);
+        loadDiskFile(&disk, diskPath);
     } else {
         FILE* file = fopen(argv[1], "rb");
         if (file == NULL) {
@@ -117,16 +151,24 @@ int main (int argc, const char* argv[]) {
         cartBytes = malloc(cartLength);
         cartLength = fread(cartBytes, 1, cartLength, file);
         fclose(file);
+
+        // Look for disk file
+        diskPath = malloc(strlen(argv[1]) + sizeof(DISK_FILE_EXT));
+        strcpy(diskPath, argv[1]);
+        strcat(diskPath, DISK_FILE_EXT);
+        loadDiskFile(&disk, diskPath);
     }
 
     audioInit();
 
     uint8_t* memory = w4_wasmInit();
-    w4_runtimeInit(memory, NULL);
+    w4_runtimeInit(memory, (uint8_t*)&disk);
 
     w4_wasmLoadModule(cartBytes, cartLength);
 
     w4_windowBoot(title);
 
     audioUninit();
+
+    saveDiskFile(&disk, diskPath);
 }

--- a/runtimes/native/src/backend/main_libretro.c
+++ b/runtimes/native/src/backend/main_libretro.c
@@ -23,8 +23,7 @@ static bool wasmCopy = false;
 
 static uint8_t* memory;
 
-// 1024 bytes plus the 2 byte size header
-static uint8_t disk[1026] = { 0 };
+static w4_Disk disk = { 0 };
 
 static void audio_set_state (bool enable) {
 }
@@ -111,7 +110,7 @@ void retro_cheat_set (unsigned index, bool enabled, const char *code) {
 void* retro_get_memory_data (unsigned id) {
     switch (id) {
     case RETRO_MEMORY_SAVE_RAM:
-        return disk;
+        return &disk;
     case RETRO_MEMORY_SYSTEM_RAM:
         return memory;
     default:
@@ -209,7 +208,7 @@ bool retro_load_game (const struct retro_game_info* game) {
     environ_cb(RETRO_ENVIRONMENT_SET_AUDIO_CALLBACK, &audio_cb);
 
     memory = w4_wasmInit();
-    w4_runtimeInit(memory, disk);
+    w4_runtimeInit(memory, &disk);
     w4_wasmLoadModule(wasmData, wasmLength);
 
     return true;
@@ -227,7 +226,7 @@ void retro_unload_game () {
 }
 
 void retro_reset () {
-    w4_runtimeInit(memory, disk);
+    w4_runtimeInit(memory, &disk);
     w4_wasmLoadModule(wasmData, wasmLength);
 }
 

--- a/runtimes/native/src/runtime.c
+++ b/runtimes/native/src/runtime.c
@@ -28,23 +28,18 @@ typedef struct {
 } Memory;
 
 typedef struct {
-    uint16_t size;
-    uint8_t data[1024];
-} Disk;
-
-typedef struct {
     Memory memory;
-    Disk disk;
+    w4_Disk disk;
     bool firstFrame;
 } SerializedState;
 
 static Memory* memory;
-static Disk* disk;
+static w4_Disk* disk;
 static bool firstFrame;
 
 void w4_runtimeInit (uint8_t* memoryBytes, uint8_t* diskBytes) {
     memory = (Memory*)memoryBytes;
-    disk = (Disk*)diskBytes;
+    disk = (w4_Disk*)diskBytes;
     firstFrame = true;
 
     // Set memory to initial state
@@ -195,13 +190,13 @@ int w4_runtimeSerializeSize () {
 void w4_runtimeSerialize (void* dest) {
     SerializedState* state = dest;
     memcpy(&state->memory, memory, 0xffff);
-    memcpy(&state->disk, disk, sizeof(Disk));
+    memcpy(&state->disk, disk, sizeof(w4_Disk));
     state->firstFrame = firstFrame;
 }
 
 void w4_runtimeUnserialize (const void* src) {
     const SerializedState* state = src;
     memcpy(memory, &state->memory, 0xffff);
-    memcpy(disk, &state->disk, sizeof(Disk));
+    memcpy(disk, &state->disk, sizeof(w4_Disk));
     firstFrame = state->firstFrame;
 }

--- a/runtimes/native/src/runtime.c
+++ b/runtimes/native/src/runtime.c
@@ -37,9 +37,9 @@ static Memory* memory;
 static w4_Disk* disk;
 static bool firstFrame;
 
-void w4_runtimeInit (uint8_t* memoryBytes, uint8_t* diskBytes) {
+void w4_runtimeInit (uint8_t* memoryBytes, w4_Disk* diskBytes) {
     memory = (Memory*)memoryBytes;
-    disk = (w4_Disk*)diskBytes;
+    disk = diskBytes;
     firstFrame = true;
 
     // Set memory to initial state

--- a/runtimes/native/src/runtime.h
+++ b/runtimes/native/src/runtime.h
@@ -20,7 +20,7 @@ typedef struct {
     uint8_t data[1024];
 } w4_Disk;
 
-void w4_runtimeInit (uint8_t* memory, uint8_t* disk);
+void w4_runtimeInit (uint8_t* memory, w4_Disk* disk);
 
 void w4_runtimeSetGamepad (int idx, uint8_t gamepad);
 void w4_runtimeSetMouse (int16_t x, int16_t y, uint8_t buttons);

--- a/runtimes/native/src/runtime.h
+++ b/runtimes/native/src/runtime.h
@@ -15,6 +15,11 @@
 #define W4_MOUSE_RIGHT 2
 #define W4_MOUSE_MIDDLE 4
 
+typedef struct {
+    uint16_t size;
+    uint8_t data[1024];
+} w4_Disk;
+
 void w4_runtimeInit (uint8_t* memory, uint8_t* disk);
 
 void w4_runtimeSetGamepad (int idx, uint8_t gamepad);


### PR DESCRIPTION
Will use the `<filepath>.disk` as filename for the save disk.

When running wasm files directly, the name will become `my_game.wasm.disk`.
When running bundles, the name will become `my_game_bundle.disk` (or `my_game_bundle.exe.disk` on Windows).
This could be changed to trim the extension, but since linux doesn't use file extensions for executables, the code would vary depending on OS.

The reason for exposing the Disk struct and not simply copying the struct (like libretro does) is to make disk files not dependent on endianness (and as such transferrable between different platforms).
I otherwise kept the interface for `w4_runtimeInit` as to not break libretro main (or any others).