### PR TITLE
Fix off-by-one for APU timings

### DIFF
--- a/runtimes/native/src/apu.c
+++ b/runtimes/native/src/apu.c
@@ -72,11 +72,11 @@ static uint16_t getCurrentFrequency (const Channel* channel) {
 }
 
 static int16_t getCurrentVolume (const Channel* channel) {
-    if (time > channel->sustainTime) {
+    if (time >= channel->sustainTime) {
         return ramp(channel->volume, 0, channel->sustainTime, channel->releaseTime);
-    } else if (time > channel->decayTime) {
+    } else if (time >= channel->decayTime) {
         return channel->volume;
-    } else if (time > channel->attackTime) {
+    } else if (time >= channel->attackTime) {
         return ramp(MAX_VOLUME, channel->volume, channel->attackTime, channel->decayTime);
     } else {
         return ramp(0, MAX_VOLUME, channel->startTime, channel->attackTime);


### PR DESCRIPTION
I messed around with APU on native and after hearing pops, noticed that the timings for `getCurrentVolume` were off by one.

As example, if you were to play a `tone` with `a`, `d`, and `r` all set to `0`, `channel->sustainTime` would be set to `time` ([see lines 106-109](https://github.com/JerwuQu/wasm4/blob/6790d3c77805eb2140fc903fa5be5e9fd2402a15/runtimes/native/src/apu.c#L106L109)), meaning it should start sustaining immediately, but since the comparator is `>`, you instead get one tick of attack, meaning you would get pops if you were to chain `tone`s after each other.