### PR TITLE
Fix oval drawing bug on the web runtime

### DIFF
--- a/runtimes/web/src/framebuffer.js
+++ b/runtimes/web/src/framebuffer.js
@@ -182,8 +182,8 @@ export class Framebuffer {
                 if (dc0 !== 0) {
                     const start = x0 - x + 1;
                     const end = x0 + x;
-                    this.drawHLineFast(fillColor, start, y0 + y, end); /*   I and III. Quadrant */
-                    this.drawHLineFast(fillColor, start, y0 - y, end); /*  II and IV. Quadrant */
+                    this.drawHLineUnclipped(fillColor, start, y0 + y, end); /*   I and III. Quadrant */
+                    this.drawHLineUnclipped(fillColor, start, y0 - y, end); /*  II and IV. Quadrant */
                 }
 
                 y++;


### PR DESCRIPTION
Solves issue #347

I noticed the issue only applied to web, and the reason was that the wrong line drawing method was being used.
Compare [native](https://github.com/aduros/wasm4/blob/5fc0583b5c0cd1e3b61a915f72c985f625da53b5/runtimes/native/src/framebuffer.c#L190L191) with [web](https://github.com/aduros/wasm4/blob/5fc0583b5c0cd1e3b61a915f72c985f625da53b5/runtimes/web/src/framebuffer.js#L185L186).