### PR TITLE
Add peak amplitude to ADSR specification

### DIFF
--- a/examples/sound-demo/src/main.c
+++ b/examples/sound-demo/src/main.c
@@ -23,6 +23,7 @@ int values[] = {
     /* 255, */
     0,
     100,
+    100,
     0,
     0,
 };
@@ -34,6 +35,7 @@ const int MAX_VALUES[] = {
     255,
     255,
     255,
+    100,
     100,
     3,
     3,
@@ -91,9 +93,10 @@ void update () {
     drawControl("DECAY", x, y + 3*spacing, 3);
     drawControl("SUSTN", x, y + 4*spacing, 4);
     drawControl("RLEAS", x, y + 5*spacing, 5);
-    drawControl("VOLUM", x, y + 6*spacing, 6);
-    drawControl("CHNNL", x, y + 7*spacing, 7);
-    drawControl(" MODE", x, y + 8*spacing, 8);
+    drawControl(" PEAK", x, y + 6*spacing, 6);
+    drawControl("VOLUM", x, y + 7*spacing, 7);
+    drawControl("CHNNL", x, y + 8*spacing, 8);
+    drawControl(" MODE", x, y + 9*spacing, 9);
 
     *DRAW_COLORS = 4;
     text("Arrows: Adjust\nX: Play tone", x, 8);
@@ -105,7 +108,7 @@ void update () {
     char pressedThisFrame = gamepad & (gamepad ^ lastGamepadState);
     lastGamepadState = gamepad;
 
-    if ((pressedThisFrame & BUTTON_DOWN) && arrowIdx < 8) {
+    if ((pressedThisFrame & BUTTON_DOWN) && arrowIdx < 9) {
         ++arrowIdx;
     }
     if ((pressedThisFrame & BUTTON_UP) && arrowIdx > 0) {
@@ -132,14 +135,15 @@ void update () {
         int decay = values[3];
         int sustain = values[4];
         int release = values[5];
-        int volume = values[6];
-        int channel = values[7];
-        int mode = values[8];
-        tracef("freq1=%d freq2=%d attack=%d decay=%d sustain=%d release=%d volume=%d channel=%d mode=%d",
-            freq1, freq2, attack, decay, sustain, release, volume, channel, mode);
-        tracef("tone(%d | (%d << 16), (%d << 24) | (%d << 16) | %d | (%d << 8), %d, %d | (%d << 2))",
-            freq1, freq2, attack, decay, sustain, release, volume, channel, mode);
+        int peakVolume = values[6];
+        int sustainVolume = values[7];
+        int channel = values[8];
+        int mode = values[9];
+        tracef("freq1=%d freq2=%d attack=%d decay=%d sustain=%d release=%d peakVolume=%d sustainVolume=%d channel=%d mode=%d",
+            freq1, freq2, attack, decay, sustain, release, peakVolume, sustainVolume, channel, mode);
+        tracef("tone(%d | (%d << 16), (%d << 24) | (%d << 16) | %d | (%d << 8), (%d << 8) | %d, %d |(%d << 2))",
+            freq1, freq2, attack, decay, sustain, release, peakVolume, sustainVolume, channel, mode);
         trace("");
-        tone(freq1 | (freq2 << 16), (attack << 24) | (decay << 16) | sustain | (release << 8), volume, channel | (mode << 2));
+        tone(freq1 | (freq2 << 16), (attack << 24) | (decay << 16) | sustain | (release << 8), (peakVolume << 8) | sustainVolume, channel | (mode << 2));
     }
 }

--- a/runtimes/native/src/apu.c
+++ b/runtimes/native/src/apu.c
@@ -28,7 +28,7 @@ typedef struct {
     unsigned long long releaseTime;
 
     /** Sustain volume level. */
-    int16_t volume;
+    int16_t sustainVolume;
 
      /** Peak volume level (at the end of the attack phase). */
     int16_t peakVolume;
@@ -76,11 +76,11 @@ static uint16_t getCurrentFrequency (const Channel* channel) {
 
 static int16_t getCurrentVolume (const Channel* channel) {
     if (time > channel->sustainTime) {
-        return ramp(channel->volume, 0, channel->sustainTime, channel->releaseTime);
+        return ramp(channel->sustainVolume, 0, channel->sustainTime, channel->releaseTime);
     } else if (time > channel->decayTime) {
-        return channel->volume;
+        return channel->sustainVolume;
     } else if (time > channel->attackTime) {
-        return ramp(channel->peakVolume, channel->volume, channel->attackTime, channel->decayTime);
+        return ramp(channel->peakVolume, channel->sustainVolume, channel->attackTime, channel->decayTime);
     } else {
         return ramp(0, channel->peakVolume, channel->startTime, channel->attackTime);
     }
@@ -114,7 +114,7 @@ void w4_apuTone (int frequency, int duration, int volume, int flags) {
     channel->decayTime = channel->attackTime + SAMPLE_RATE*decay/60;
     channel->sustainTime = channel->decayTime + SAMPLE_RATE*sustain/60;
     channel->releaseTime = channel->sustainTime + SAMPLE_RATE*release/60;
-    channel->volume = MAX_VOLUME * sustainVolume/100;
+    channel->sustainVolume = MAX_VOLUME * sustainVolume/100;
     channel->peakVolume = peakVolume ? MAX_VOLUME * peakVolume/100 : MAX_VOLUME;
 
     if (channelIdx == 0 || channelIdx == 1) {

--- a/runtimes/web/src/apu.js
+++ b/runtimes/web/src/apu.js
@@ -66,6 +66,9 @@ export class APU {
         const decay = ((duration >> 16) & 0xff) / 60;
         const attack = ((duration >> 24) & 0xff) / 60;
 
+        const sustainVolume = volume & 0xff;
+        const peakVolume = (volume >> 8) & 0xff;
+
         const channel = flags & 0x3;
         const mode = (flags >> 2) & 0x3;
 
@@ -75,9 +78,12 @@ export class APU {
         const sustainTime = decayTime + sustain;
         const releaseTime = sustainTime + release;
 
-        // Peak level of any channel should be -12 dB, or a quarter of full volume
-        let peakLevel = 0.25;
-        let sustainLevel = volume/100 * peakLevel;
+        // Maximum level of any channel should be -12 dB, or a quarter of full volume
+        let maxLevel = 0.25;
+        // The level reached by the attack phase
+        let peakLevel = peakVolume ? peakVolume/100 * maxLevel : maxLevel;
+        // The level sustained for the duration of the sustain phase 
+        let sustainLevel = sustainVolume/100 * maxLevel;
 
         let node;
         const existingNode = this.nodes[channel];

--- a/site/docs/guides/audio.md
+++ b/site/docs/guides/audio.md
@@ -79,7 +79,7 @@ The [duty cycle](https://en.wikipedia.org/wiki/Duty_cycle) of the pulse channels
 with additional flags:
 
 | Flag         | Duty Cycle      |
-| ---          | ---             |
+| ------------ | --------------- |
 | `TONE_MODE1` | 12.5% (default) |
 | `TONE_MODE2` | 25%             |
 | `TONE_MODE3` | 50%             |
@@ -195,17 +195,29 @@ w4.tone(262 | (523 << 16), 60, 100, w4.TONE_PULSE1);
 
 </MultiLanguageCode>
 
-## ADSR Envelope
 
+## Volume 
+
+There are two volume levels that can be passed to the tone function
+
+| Volume  | Shift | Description                                            |
+| ------- | ----- | ------------------------------------------------------ |
+| Sustain | 0     | The volume sustained for the `sustain` phase duration. |
+| Peak    | 8     | The volume reached by the `attack` phase               |
+
+If the peak volume is not set (or is set to 0), the peak defaults to maximum volume.
+
+## ADSR Envelope
+ 
 [ADSR](https://en.wikipedia.org/wiki/ADSR_envelope) describes how the volume changes over time, and
 has 4 time components:
 
-| Time        | Shift | Description                                                                  |
-| ---         | ---   | ---                                                                          |
-| **A**ttack  | 24    | The time it takes to initially ramp up from 0 volume to 100% volume.         |
-| **D**ecay   | 16    | The time taken to ramp down from 100% volume to the tone `volume` parameter. |
-| **S**ustain | 0     | The time to hold the tone steady at `volume`.                                |
-| **R**elease | 8     | The time to ramp back down to 0 volume.                                      |
+| Time        | Shift | Description                                                                    |
+| ----------- | ----- | ------------------------------------------------------------------------------ |
+| **A**ttack  | 24    | The time it takes to initially ramp up from 0 volume to `peak` volume.         |
+| **D**ecay   | 16    | The time taken to ramp down from `peak` volume to the tone `volume` parameter. |
+| **S**ustain | 0     | The time to hold the tone steady at `volume`.                                  |
+| **R**elease | 8     | The time to ramp back down to 0 volume.                                        |
 
 These times are all measured in frames (1/60th of a second), and can be packed
 into the `duration` parameter.

--- a/site/docs/tutorials/snake/setting-color-palette.md
+++ b/site/docs/tutorials/snake/setting-color-palette.md
@@ -130,10 +130,10 @@ export function start(): void {
 
 ```c
 void start() {
-	PALETTE[0] = 0xfbf7f3
-	PALETTE[1] = 0xe5b083
-	PALETTE[2] = 0x426e5d
-	PALETTE[3] = 0x20283d
+	PALETTE[0] = 0xfbf7f3;
+	PALETTE[1] = 0xe5b083;
+	PALETTE[2] = 0x426e5d;
+	PALETTE[3] = 0x20283d;
 }
 ```
 </Page>


### PR DESCRIPTION
This adressess issue #331 
The specification is still not standard but this solution is backwards compatible.
`tone`'s volume parameter now accepts a peak volume with an 8 bit shift.
This volume is the peak volume reached at the end of the attack duration. 
