### PR TITLE
Add the -Wconversion -Wsign-conversion flags to the Makefile template

### DIFF
--- a/cli/assets/templates/c/Makefile
+++ b/cli/assets/templates/c/Makefile
@@ -13,7 +13,7 @@ WASM_OPT_FLAGS = -Oz --zero-filled-memory --strip-producers
 DEBUG = 0
 
 # Compilation flags
-CFLAGS = -W -Wall -Wextra -Werror -Wno-unused -MMD -MP -fno-exceptions
+CFLAGS = -W -Wall -Wextra -Werror -Wno-unused -Wconversion -Wsign-conversion -MMD -MP -fno-exceptions
 ifeq ($(DEBUG), 1)
 	CFLAGS += -DDEBUG -O0 -g
 else


### PR DESCRIPTION
Creating games using wasm4 assumes a lot of number operations.
The `-Wconversion` and `-Wsign-conversion` are added in order
to catch any subtle bugs like number overflows or casting.