### PR TITLE
cli: Change the require syntax in the `new` command source

### DIFF
--- a/cli/lib/new.js
+++ b/cli/lib/new.js
@@ -1,6 +1,6 @@
 const copy = require("recursive-copy");
 const path = require("path");
-const fs = require("fs/promises");
+const fs = require("fs").promises;
 const Mustache = require('mustache');
 
 const HELP = {


### PR DESCRIPTION
Without this change the `w4 new --lang` command fails with the
`Cannot find module 'fs/promises'` error