### PR TITLE
Change Rust template static muts to consts

### DIFF
--- a/cli/assets/templates/rust/src/wasm4.rs
+++ b/cli/assets/templates/rust/src/wasm4.rs
@@ -17,7 +17,7 @@ pub const SCREEN_SIZE: u32 = 160;
 // │                                                                           │
 // └───────────────────────────────────────────────────────────────────────────┘
 
-pub static mut PALETTE: *mut [u32; 4] = 0x04 as *mut [u32; 4];
+pub const PALETTE: *mut [u32; 4] = 0x04 as *mut [u32; 4];
 pub const DRAW_COLORS: *mut u16 = 0x14 as *mut u16;
 pub const GAMEPAD1: *const u8 = 0x16 as *const u8;
 pub const GAMEPAD2: *const u8 = 0x17 as *const u8;
@@ -27,7 +27,7 @@ pub const MOUSE_X: *const i16 = 0x1a as *const i16;
 pub const MOUSE_Y: *const i16 = 0x1c as *const i16;
 pub const MOUSE_BUTTONS: *const u8 = 0x1e as *const u8;
 pub const SYSTEM_FLAGS: *mut u8 = 0x1f as *mut u8;
-pub static mut FRAMEBUFFER: *mut [u8; 6400] = 0xa0 as *mut [u8; 6400];
+pub const FRAMEBUFFER: *mut [u8; 6400] = 0xa0 as *mut [u8; 6400];
 
 pub const BUTTON_1: u8 = 1;
 pub const BUTTON_2: u8 = 2;


### PR DESCRIPTION
This patch changes the FRAMEBUFFER and PALETTE variables in the Rust template from `pub static mut` to `pub const`, as the pointers themselves don't ever need to be mutated or have a static memory address.


In the future, we may be able to have the framebuffer directly like this:
`pub static mut FRAMEBUFFER: [u8; 6400] = unsafe { *(0xa0 as *mut [u8; 6400]) };`
but this isn't stablised yet.