### PR TITLE
Add START_TIME to retrieve when the runtime started

### DIFF
--- a/cli/assets/templates/assemblyscript/src/wasm4.ts
+++ b/cli/assets/templates/assemblyscript/src/wasm4.ts
@@ -25,6 +25,7 @@ export const MOUSE_X: usize = 0x1a;
 export const MOUSE_Y: usize = 0x1c;
 export const MOUSE_BUTTONS: usize = 0x1e;
 export const SYSTEM_FLAGS: usize = 0x1f;
+export const START_TIME: usize = 0x20;
 export const FRAMEBUFFER: usize = 0xa0;
 
 export const BUTTON_1: u8 = 1;

--- a/cli/assets/templates/c/src/wasm4.h
+++ b/cli/assets/templates/c/src/wasm4.h
@@ -35,6 +35,7 @@ WASM_EXPORT("update") void update ();
 #define MOUSE_Y ((const int16_t*)0x1c)
 #define MOUSE_BUTTONS ((const uint8_t*)0x1e)
 #define SYSTEM_FLAGS ((uint8_t*)0x1f)
+#define START_TIME ((uint64_t*)0x20)
 #define FRAMEBUFFER ((uint8_t*)0xa0)
 
 #define BUTTON_1 1

--- a/cli/assets/templates/go/w4/wasm4.go
+++ b/cli/assets/templates/go/w4/wasm4.go
@@ -29,6 +29,7 @@ var MOUSE_X = (*int16)(unsafe.Pointer(uintptr(0x1a)))
 var MOUSE_Y = (*int16)(unsafe.Pointer(uintptr(0x1c)))
 var MOUSE_BUTTONS = (*uint8)(unsafe.Pointer(uintptr(0x1e)))
 var SYSTEM_FLAGS = (*uint8)(unsafe.Pointer(uintptr(0x1f)));
+var START_TIME = (*uint64)(unsafe.Pointer(uintptr(0x20)));
 var FRAMEBUFFER = (*[6400]uint8)(unsafe.Pointer(uintptr(0xa0)))
 
 const BUTTON_1 byte = 1

--- a/cli/assets/templates/nelua/src/wasm4.nelua
+++ b/cli/assets/templates/nelua/src/wasm4.nelua
@@ -50,6 +50,7 @@ global MOUSE_X <comptime> = (@*int16)(0x1a)
 global MOUSE_Y <comptime> = (@*int16)(0x1c)
 global MOUSE_BUTTONS <comptime> = (@*uint8)(0x1e)
 global SYSTEM_FLAGS <comptime> = (@*uint8)(0x1f)
+global START_TIME <comptime> = (@*uint64)(0x20)
 global FRAMEBUFFER <comptime> = (@*[6400]uint8)(0xa0)
 
 global BUTTON_1 <comptime> = 1

--- a/cli/assets/templates/odin/src/w4/wasm4_wasm32.odin
+++ b/cli/assets/templates/odin/src/w4/wasm4_wasm32.odin
@@ -23,6 +23,7 @@ MOUSE_X       := (^i16)(uintptr(0x1a))
 MOUSE_Y       := (^i16)(uintptr(0x1c))
 MOUSE_BUTTONS := (^Mouse_Buttons)(uintptr(0x1e))
 SYSTEM_FLAGS  := (^System_Flags)(uintptr(0x1f))
+START_TIME    := (^u64)(uintptr(0x20))
 FRAMEBUFFER   := (^[6400]u8)(uintptr(0xa0)) // 4 bits * (160*160)
 
 Palette :: distinct [4]u32

--- a/cli/assets/templates/rust/src/wasm4.rs
+++ b/cli/assets/templates/rust/src/wasm4.rs
@@ -27,6 +27,7 @@ pub const MOUSE_X: *const i16 = 0x1a as *const i16;
 pub const MOUSE_Y: *const i16 = 0x1c as *const i16;
 pub const MOUSE_BUTTONS: *const u8 = 0x1e as *const u8;
 pub const SYSTEM_FLAGS: *mut u8 = 0x1f as *mut u8;
+pub const START_TIME: *mut u64 = 0x20 as *mut u64;
 pub static mut FRAMEBUFFER: *mut [u8; 6400] = 0xa0 as *mut [u8; 6400];
 
 pub const BUTTON_1: u8 = 1;

--- a/cli/assets/templates/wat/main.wat
+++ b/cli/assets/templates/wat/main.wat
@@ -77,6 +77,7 @@
 (global $MOUSE_Y i32 (i32.const 0x1c))
 (global $MOUSE_BUTTONS i32 (i32.const 0x1e))
 (global $SYSTEM_FLAGS i32 (i32.const 0x1f))
+(global $START_TIME u64 (u64.const 0x20))
 (global $FRAMEBUFFER i32 (i32.const 0xa0))
 
 (global $BUTTON_1 i32 (i32.const 1))

--- a/cli/assets/templates/zig/src/wasm4.zig
+++ b/cli/assets/templates/zig/src/wasm4.zig
@@ -25,6 +25,7 @@ pub const MOUSE_X: *const i16 = @intToPtr(*const i16, 0x1a);
 pub const MOUSE_Y: *const i16 = @intToPtr(*const i16, 0x1c);
 pub const MOUSE_BUTTONS: *const u8 = @intToPtr(*const u8, 0x1e);
 pub const SYSTEM_FLAGS: *u8 = @intToPtr(*u8, 0x1f);
+pub const START_TIME: *u64 = @intToPtr(*u64, 0x20);
 pub const FRAMEBUFFER: *[6400]u8 = @intToPtr(*[6400]u8, 0xA0);
 
 pub const BUTTON_1: u8 = 1;

--- a/devtools/web/src/constants.ts
+++ b/devtools/web/src/constants.ts
@@ -17,6 +17,7 @@ export const ADDR_MOUSE_X = 0x1a;
 export const ADDR_MOUSE_Y = 0x1c;
 export const ADDR_MOUSE_BUTTONS = 0x1e;
 export const ADDR_SYSTEM_FLAGS = 0x1f;
+export const ADDR_START_TIME = 0x20;
 export const ADDR_FRAMEBUFFER = 0xa0;
 
 export const BUTTON_X = 1;
@@ -82,6 +83,10 @@ export const memoryMap: Readonly<Record<string, Range>> = {
   SYSTEM_FLAGS: {
     offset: ADDR_SYSTEM_FLAGS,
     len: 1,
+  },
+  START_TIME: {
+    offset: ADDR_START_TIME,
+    len: 8,
   },
   RESERVED: {
     offset: 0x0020,

--- a/devtools/web/src/models/MemoryView.ts
+++ b/devtools/web/src/models/MemoryView.ts
@@ -44,6 +44,7 @@ export class MemoryView implements MemoryViewComputedProperties {
   readonly pointerPos: Point;
   readonly mouseBtnByte: number;
   readonly systemFlags: number;
+  readonly startTime: number;
   readonly gamepads: number[];
   readonly palette: [number, number, number, number];
   readonly drawColors: number;
@@ -58,6 +59,7 @@ export class MemoryView implements MemoryViewComputedProperties {
     this.palette = extractPalette(dataView);
     this.gamepads = extractGamepads(dataView, bufferedData);
     this.systemFlags = dataView.getUint8(constants.ADDR_SYSTEM_FLAGS);
+    this.startTime = dataView.getUint32(constants.ADDR_START_TIME); // TODO: DataView doesn't support uint64?
     this.mouseBtnByte =
       dataView.getUint8(constants.ADDR_MOUSE_BUTTONS) |
       bufferedData.mouseButtons;

--- a/examples/snake/package-lock.json
+++ b/examples/snake/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "wasm4-snake",
       "version": "1.0.0",
       "devDependencies": {
         "assemblyscript": "^0.19.11"

--- a/examples/snake/src/wasm4.ts
+++ b/examples/snake/src/wasm4.ts
@@ -25,6 +25,7 @@ export const MOUSE_X: usize = 0x1a;
 export const MOUSE_Y: usize = 0x1c;
 export const MOUSE_BUTTONS: usize = 0x1e;
 export const SYSTEM_FLAGS: usize = 0x1f;
+export const START_TIME: usize = 0x20;
 export const FRAMEBUFFER: usize = 0xa0;
 
 export const BUTTON_1: u8 = 1;

--- a/runtimes/native/src/runtime.c
+++ b/runtimes/native/src/runtime.c
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 #include <m3_env.h>
 
 #include "apu.h"
@@ -23,7 +24,8 @@ typedef struct {
     int16_t mouseY;
     uint8_t mouseButtons;
     uint8_t systemFlags;
-    uint8_t _reserved[128];
+    uint64_t startTime;
+    uint8_t _reserved[120];
     uint8_t framebuffer[WIDTH*HEIGHT>>2];
     uint8_t _user[58975];
 } Memory;
@@ -53,6 +55,7 @@ void w4_runtimeInit (uint8_t* memoryBytes, w4_Disk* diskBytes) {
     memory->drawColors[1] = 0x12;
     m3ApiWriteMem16(&memory->mouseX, 0x7fff);
     m3ApiWriteMem16(&memory->mouseY, 0x7fff);
+    m3ApiWriteMem64(&memory->startTime, (uint64_t)(time(NULL)));
 
     w4_apuInit();
     w4_framebufferInit(&memory->drawColors, memory->framebuffer);

--- a/runtimes/web/src/constants.js
+++ b/runtimes/web/src/constants.js
@@ -28,6 +28,7 @@ export const ADDR_MOUSE_X = 0x1a;
 export const ADDR_MOUSE_Y = 0x1c;
 export const ADDR_MOUSE_BUTTONS = 0x1e;
 export const ADDR_SYSTEM_FLAGS = 0x1f;
+export const ADDR_START_TIME = 0x20;
 export const ADDR_FRAMEBUFFER = 0xa0;
 
 export const BUTTON_X = 1;

--- a/runtimes/web/src/runtime.js
+++ b/runtimes/web/src/runtime.js
@@ -50,6 +50,10 @@ export class Runtime {
         return this.data.getUint8(constants.ADDR_SYSTEM_FLAGS) & mask;
     }
 
+    getStartTime () {
+        return this.data.getUint32(constants.ADDR_START_TIME) & mask; // TODO: dataView doesn't support getUint64?
+    }
+
     maskGamepad (idx, mask, down) {
         const addr = constants.ADDR_GAMEPAD1 + idx;
         let buttons = this.data.getUint8(addr);
@@ -100,6 +104,9 @@ export class Runtime {
         // Initialize the mouse off screen
         this.data.setInt16(constants.ADDR_MOUSE_X, 0x7fff, true);
         this.data.setInt16(constants.ADDR_MOUSE_Y, 0x7fff, true);
+
+        const currentDate = new Date();
+        this.data.setBigUint64(constants.ADDR_START_TIME, currentDate.getTime());
     }
 
     async load (wasmBuffer) {

--- a/scripts/generate-memory-map
+++ b/scripts/generate-memory-map
@@ -20,7 +20,9 @@ const memory = {
 
     SYSTEM_FLAGS: 1,
 
-    _RESERVED: 128,
+    START_TIME: 8,
+
+    _RESERVED: 120,
 
     // Framebuffer should be 64 bit aligned
     FRAMEBUFFER: 160*160 >> 2,
@@ -32,6 +34,7 @@ const cTypes = {
     MOUSE_X: "const int16_t",
     MOUSE_Y: "const int16_t",
     SYSTEM_FLAGS: "uint8_t",
+    START_TIME: "uint64_t",
     FRAMEBUFFER: "uint8_t",
 };
 
@@ -53,6 +56,7 @@ const neluaTypes = {
     MOUSE_X: "int16",
     MOUSE_Y: "int16",
     SYSTEM_FLAGS: "uint8",
+    START_TIME: "uint64",
     FRAMEBUFFER: "uint8",
 };
 

--- a/site/docs/reference/memory.md
+++ b/site/docs/reference/memory.md
@@ -12,7 +12,8 @@ WASM-4 uses a fixed memory layout of 64 KB.
 | `$001c` | 2            | [MOUSE_Y](#mouse_y)             |
 | `$001e` | 1            | [MOUSE_BUTTONS](#mouse_buttons) |
 | `$001f` | 1            | [SYSTEM_FLAGS](#system_flags)   |
-| `$0020` | 128          | Reserved for future use         |
+| `$0020` | 8            | [START_TIME](#start_time)         |
+| `$0028` | 112          | Reserved for future use         |
 | `$00a0` | 6400         | [FRAMEBUFFER](#framebuffer)     |
 | `$19a0` | 58975        | Available program memory        |
 
@@ -90,6 +91,10 @@ Byte containing flags that modify WASM-4's operation. By default all flags are o
 | --- | ---                           | ---                                               |
 | 0   | `SYSTEM_PRESERVE_FRAMEBUFFER` | Prevent clearing the framebuffer between frames.  |
 | 1   | `SYSTEM_HIDE_GAMEPAD_OVERLAY` | Hide the gamepad UI overlay on mobile.            |
+
+### START_TIME
+
+Unsigned 64 bit integer representing the unix timestamp of when the cartridge started.
 
 ### FRAMEBUFFER
 


### PR DESCRIPTION
Introduces a `START_TIME` constant which is an unsigned 64 bit integer representing the unix timestamp of when the runtime started. This would be helpful for creating time-sensative applciations, like clocks, calendars, or persistent games like [Tamagotchi](https://en.wikipedia.org/wiki/Tamagotchi).

This isn't ready to be merged as it...

- [ ] Needs more testing
- [ ] Needs some tweaks in some of the languages (DataView doesn't support uint64 right now for instance)
- [ ] Unsure about the name