### PR TITLE
web: Add disk localStorage prefix

### DIFF
--- a/cli/assets/bundle/template.html
+++ b/cli/assets/bundle/template.html
@@ -15,6 +15,9 @@
     {{#html.iconUrl}}
     <link rel="shortcut icon" href="{{html.iconUrl}}" />
     {{/html.iconUrl}}
+    {{#html.diskPrefix}}
+    <script id="wasm4-disk-prefix" type="text/plain">{{{html.diskPrefix}}}</script>
+    {{/html.diskPrefix}}
     <title>{{html.title}}</title>
     <style type="text/css" id="wasm4-css">{{{html.wasm4Css}}}</style>
   </head>

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -169,6 +169,7 @@ program.command("bundle <cart>")
     .option("--icon-file <file>", `Game icon image. Supported types: ${supportedIconExtensions().join(', ')}.\nTakes precedence over --icon-url`)
     .option("--icon-url <url>", 'Favicon icon url')
     .option("--timestamp", 'Adds build timestamp to output', false)
+    .option("--html-disk-prefix <prefix>", "Specify a prefix for the disk localStorage key. Defaults to game title")
     .action((cart, opts) => {
         const bundle = require("./lib/bundle");
         bundle.run(cart, opts);

--- a/cli/lib/bundle.js
+++ b/cli/lib/bundle.js
@@ -60,6 +60,7 @@ async function bundleHtml (cartFile, htmlFile, opts) {
         html: {
             title: opts.title,
             description: opts.description,
+            diskPrefix: opts.htmlDiskPrefix ?? opts.title,
             wasmCartJson,
             wasm4Css,
             wasm4js,

--- a/runtimes/web/src/index.js
+++ b/runtimes/web/src/index.js
@@ -23,6 +23,8 @@ if (author != null) {
     document.getElementById("author").textContent = "by "+author;
 }
 
+const diskName = (document.getElementById("wasm4-disk-prefix")?.textContent ?? qs.get('disk-prefix') ?? title) + "-disk";
+
 function setClass (element, className, enabled) {
     if (enabled) {
         element.classList.add(className);
@@ -62,6 +64,8 @@ async function loadCartWasm () {
     if (DEVELOPER_BUILD) {
         devtoolsManager = await import('@wasm4/web-devtools').then(({ DevtoolsManager}) => new DevtoolsManager())
     }
+
+    runtime.diskName = diskName;
 
     if (screenshot != null) {
         // Wait until the initial focus before starting the runtime

--- a/runtimes/web/src/runtime.js
+++ b/runtimes/web/src/runtime.js
@@ -21,6 +21,8 @@ export class Runtime {
 
         this.apu = new APU();
 
+        this.diskName = 'disk';
+
         this.memory = new WebAssembly.Memory({initial: 1, maximum: 1});
         this.data = new DataView(this.memory.buffer);
 
@@ -208,7 +210,7 @@ export class Runtime {
     diskr (destPtr, size) {
         let str;
         try {
-            str = localStorage.getItem("disk");
+            str = localStorage.getItem(this.diskName);
         } catch (error) {
             if (constants.DEBUG) {
                 console.error(error);
@@ -228,7 +230,7 @@ export class Runtime {
         const src = new Uint8Array(this.memory.buffer, srcPtr, bytesWritten);
         const str = z85.encode(src);
         try {
-            localStorage.setItem("disk", str);
+            localStorage.setItem(this.diskName, str);
         } catch (error) {
             if (constants.DEBUG) {
                 console.error(error);
@@ -298,7 +300,7 @@ export class Runtime {
                 case 115: // s
                     let cstrPtr = this.data.getUint32(argPtr, true);
                     output += this.getCString(cstrPtr);
-					argPtr += 4;
+                    argPtr += 4;
                     break;
                 case 102: // f
                     output += this.data.getFloat64(argPtr, true);

--- a/site/src/components/PlayCart.js
+++ b/site/src/components/PlayCart.js
@@ -6,6 +6,7 @@ import { Giscus } from "@giscus/react";
 
 function Embed ({ slug, title, author }) {
     let params = "?url="+encodeURIComponent(`/carts/${slug}.wasm`);
+    params += "&disk-prefix="+encodeURIComponent(slug);
     params += "&screenshot="+encodeURIComponent(`/carts/${slug}.png`);
     if (title) {
         params += "&title="+encodeURIComponent(title);


### PR DESCRIPTION
Solves issue #357.

Runtime itself defaults to `disk`.
Bundles default to `<title>-disk` with a CLI option to manually set the prefix.
Site uses `<slug>-disk`.
