### PR TITLE
Feature: handle tracef's `%c` as unicode code point

### DIFF
--- a/runtimes/web/src/runtime.ts
+++ b/runtimes/web/src/runtime.ts
@@ -318,7 +318,7 @@ export class Runtime {
                     output += "%";
                     break;
                 case 99: // c
-                    output += String.fromCharCode(this.data.getInt32(argPtr, true));
+                    output += String.fromCodePoint(this.data.getInt32(argPtr, true));
                     argPtr += 4;
                     break;
                 case 100: // d


### PR DESCRIPTION
Previously converted such character to UTF-16 char code,
so large unicode characters would have been truncated.
Now it's possible to pass unicode characters.