### PR TITLE
Fix some typos in the docs

### DIFF
--- a/site/docs/getting-started/setup.md
+++ b/site/docs/getting-started/setup.md
@@ -201,7 +201,7 @@ w4 run build/cart.wasm
 <Page value="porth">
 
 :::note
-[Porth](https://gitlab.com/tsoding/porth#porth) is currently a work in progress language. Anythining can change at any moment without notice.
+[Porth](https://gitlab.com/tsoding/porth#porth) is currently a work in progress language. Anything can change at any moment without notice.
 :::
 
 To compile Porth projects you will need to download [4orth](https://github.com/FrankWPA/4orth#4orth) and add it to `$PATH`.

--- a/site/docs/guides/distribution.md
+++ b/site/docs/guides/distribution.md
@@ -11,7 +11,7 @@ w4 bundle cart.wasm --title "My Game" --html my-game.html
 The bundled HTML contains no external dependencies, works offline, and can be easily shared on sites like [itch.io](https://itch.io/).
 
 For saving disks, the localStorage key used will be based on the game title you supply.
-Alternatively, you can specifiy a localStorage key prefix manually with `--html-disk-prefix <prefix>`.
+Alternatively, you can specify a localStorage key prefix manually with `--html-disk-prefix <prefix>`.
 This is useful to prevent disk conflicts between games.
 
 ## Bundle to Windows/Mac/Linux executable

--- a/site/docs/tutorials/snake/collision-detection.md
+++ b/site/docs/tutorials/snake/collision-detection.md
@@ -150,7 +150,7 @@ Once this done, simply relocate the fruit:
 fruit = { x = math.random(0, 19), y = math.random(0,19) }
 ```
 
-Just this however will realocate the fruit in the same places for every run because it uses always the same seed, to generate a random seed we need to call `math.randomseed` function with at least one argument, which can be `frame_count`:
+Just this however will reallocate the fruit in the same places for every run because it uses always the same seed, to generate a random seed we need to call `math.randomseed` function with at least one argument, which can be `frame_count`:
 
 ```lua
 math.randomseed(frame_count)

--- a/site/docs/tutorials/snake/placing-the-fruit.md
+++ b/site/docs/tutorials/snake/placing-the-fruit.md
@@ -517,7 +517,7 @@ Now you need to import the image. For this, the WASM-4 CLI tool `w4` comes with 
 This will output some code ending in the following to the terminal:
 
 ```c
-cconst uint8_t fruit_sprite[] = {
+const uint8_t fruit_sprite[] = {
     0x00,0xa0,0x02,0x00,0x0e,0xf0,0x36,0x5c,0xd6,0x57,0xd5,0x57,0x35,0x5c,0x0f,0xf0
 };
 ```


### PR DESCRIPTION
As I had a typo to fix in the Porth docs, i used this opportunity to run a spell checker to see if anything else could be corrected.