### PR TITLE
Support defining template file for standalone HTML bundle

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -178,6 +178,7 @@ program.command("bundle <cart>")
     .option("--icon-url <url>", 'Favicon icon url')
     .option("--timestamp", 'Adds build timestamp to output', false)
     .option("--html-disk-prefix <prefix>", "Specify a prefix for the disk localStorage key. Defaults to game title")
+    .option("--html-template <file>", "Mustache HTML template file for standalone HTML. Defaults to a built-in template.")
     .action((cart, opts) => {
         const bundle = require("./lib/bundle");
         bundle.run(cart, opts);

--- a/cli/lib/bundle.js
+++ b/cli/lib/bundle.js
@@ -52,7 +52,7 @@ async function bundleHtml (cartFile, htmlFile, opts) {
     }
 
     const template = await fs.readFile(
-        path.resolve(__dirname, '../assets/bundle/template.html'),
+        (opts.htmlTemplate != null) ? opts.htmlTemplate : path.resolve(__dirname, '../assets/bundle/template.html'),
         { encoding: 'utf-8' }
     );
 

--- a/site/docs/guides/distribution.md
+++ b/site/docs/guides/distribution.md
@@ -14,6 +14,37 @@ For saving disks, the localStorage key used will be based on the game title you 
 Alternatively, you can specify a localStorage key prefix manually with `--html-disk-prefix <prefix>`.
 This is useful to prevent disk conflicts between games.
 
+You can customize the generated HTML file by giving a [Mustache](https://mustache.github.io/) template file with option `--html-template <file>`.
+Example of a template file:
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no">
+  {{#html.metadata}}
+  <meta name="{{name}}" content="{{content}}">
+  {{/html.metadata}}
+  {{#html.description}}
+  <meta name="description" content="{{html.description}}">
+  {{/html.description}}
+  {{#html.iconUrl}}
+  <link rel="shortcut icon" href="{{html.iconUrl}}">
+  {{/html.iconUrl}}
+  {{#html.diskPrefix}}
+  <script id="wasm4-disk-prefix" type="text/plain">{{{html.diskPrefix}}}</script>
+  {{/html.diskPrefix}}
+  <title>{{html.title}}</title>
+  <style>{{{html.wasm4Css}}}</style>
+</head>
+<body>
+  <script id="wasm4-cart-json" type="application/json">{{{html.wasmCartJson}}}</script>
+  <script>{{{html.wasm4js}}}</script>
+  <wasm4-app></wasm4-app>
+</body>
+</html>
+```
+
 ## Bundle to Windows/Mac/Linux executable
 
 Native executables for multiple platforms can also be bundled:

--- a/site/docs/reference/cli.md
+++ b/site/docs/reference/cli.md
@@ -292,17 +292,18 @@ w4 bundle --windows wormhole.exe --title "Wormhole Deluxe" wormhole.wasm
 
 **Options:**
 
-| Option                    | Default value | Description                                                                           |
-| ------------------------- | ------------- | ------------------------------------------------------------------------------------- |
-| --html OUTPUT             |               | Bundle standalone HTML file                                                           |
-| --windows OUTPUT          |               | Bundle a native Windows executable                                                    |
-| --mac OUTPUT              |               | Bundle a native macOS executable                                                      |
-| --linux OUTPUT            |               | Bundle a native Linux executable                                                      |
-| --title TITLE             | "WASM-4 Game" | Title of the game                                                                     |
-| --description DESCRIPTION |               | The description of the game                                                           |
-| --icon-file FILE          |               | Icon of the game. Supported are png, ico and svg.<br/>This will override `--icon-url` |
-| --icon-url URL            |               | URL to the the Favicon of the game                                                    |
-| --timestamp               | false         | Adds build timestamp to output                                                        |
+| Option                    | Default value     | Description                                                                           |
+| ------------------------- | ----------------- | ------------------------------------------------------------------------------------- |
+| --html OUTPUT             |                   | Bundle standalone HTML file                                                           |
+| --windows OUTPUT          |                   | Bundle a native Windows executable                                                    |
+| --mac OUTPUT              |                   | Bundle a native macOS executable                                                      |
+| --linux OUTPUT            |                   | Bundle a native Linux executable                                                      |
+| --title TITLE             | "WASM-4 Game"     | Title of the game                                                                     |
+| --description DESCRIPTION |                   | The description of the game                                                           |
+| --icon-file FILE          |                   | Icon of the game. Supported are png, ico and svg.<br/>This will override `--icon-url` |
+| --icon-url URL            |                   | URL to the the Favicon of the game                                                    |
+| --timestamp               | false             | Adds build timestamp to output                                                        |
+| --html-template FILE      | built-in template | Mustache HTML template file for standalone HTML.                                      |
 
 **Description:**
 


### PR DESCRIPTION
Add option `w4 build --html-template <file>`. This will specify a
Mustache template that is used when generating standalone html file.
You can use this to customize the HTML page that renders the cart.

The default template is the built-in template in cli/assets/bundle/template.html.

```html
<!doctype html>
<html lang="en">
<head>
  <meta charset="utf-8">
  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no">
  {{#html.metadata}}
  <meta name="{{name}}" content="{{content}}">
  {{/html.metadata}}
  {{#html.description}}
  <meta name="description" content="{{html.description}}">
  {{/html.description}}
  {{#html.iconUrl}}
  <link rel="shortcut icon" href="{{html.iconUrl}}">
  {{/html.iconUrl}}
  {{#html.diskPrefix}}
  <script id="wasm4-disk-prefix" type="text/plain">{{{html.diskPrefix}}}</script>
  {{/html.diskPrefix}}
  <title>{{html.title}}</title>
  <style>{{{html.wasm4Css}}}</style>
</head>
<body>
  <script id="wasm4-cart-json" type="application/json">{{{html.wasmCartJson}}}</script>
  <script>{{{html.wasm4js}}}</script>
  <wasm4-app></wasm4-app>
</body>
</html>
```