### PR TITLE
Updating to remove negative checks in Zig example

### DIFF
--- a/site/docs/tutorials/snake/moving-the-snake.md
+++ b/site/docs/tutorials/snake/moving-the-snake.md
@@ -506,9 +506,6 @@ This isn't hard either. Simple add the add the direction to the current head. An
 
         part[0].x = @mod((part[0].x + this.direction.x), 20);
         part[0].y = @mod((part[0].y + this.direction.y), 20);
-
-        if (part[0].x < 0) part[0].x = 19;
-        if (part[0].y < 0) part[0].y = 19;
     }
 ```
 


### PR DESCRIPTION
Removing the extraneous negative check from the Zig example in `moving-the-snake.md` as Zig's `@mod` instruction [always returns nonnegative numbers](https://ziglang.org/documentation/master/#mod).