### PR TITLE
Remove unnecessary import "image" in Go snake tutorial

### DIFF
--- a/site/docs/tutorials/snake/drawing-the-snake.md
+++ b/site/docs/tutorials/snake/drawing-the-snake.md
@@ -159,7 +159,7 @@ Keep in mind you need to import `cart/w4` in case your editor doesn't do this fo
 
 That's all fine, but since there is no instance of the snake, nothing can be drawn. To fix this, simply create a new variable in main and call its draw function:
 
-```go {9-18,30}
+```go {5-14,26}
 package main
 
 import "cart/w4"


### PR DESCRIPTION
In the previous step it explains that, rather than importing Point from image, you create a Point struct to reduce cart size.