### PR TITLE
Add a warning when a non-standard gamepad is detected.

### DIFF
--- a/runtimes/web/src/ui/app.ts
+++ b/runtimes/web/src/ui/app.ts
@@ -382,7 +382,7 @@ export class App extends LitElement {
                     // Let's warn once, and not use this gamepad afterwards.
                     if (!this.inputState.gamepadUnavailableWarned.has(i)) {
                         this.inputState.gamepadUnavailableWarned.add(i);
-                        console.warn("Your browser does not know the mapping for the %s gamepad (index %d) and we can't use it.", gamepad.id, i);
+                        this.notifications.show("Unsupported gamepad: " + gamepad.id);
                     }
                     continue;
                 }

--- a/runtimes/web/src/ui/app.ts
+++ b/runtimes/web/src/ui/app.ts
@@ -14,6 +14,7 @@ import { Notifications } from "./notifications";
 
 class InputState {
     gamepad = [0, 0, 0, 0];
+    gamepadUnavailableWarned = new Set<number>;
     mouseX = 0;
     mouseY = 0;
     mouseButtons = 0;
@@ -373,9 +374,17 @@ export class App extends LitElement {
                 return; // Browser doesn't support gamepads
             }
 
-            for (const gamepad of navigator.getGamepads()) {
-                if (gamepad == null || gamepad.mapping != "standard") {
-                    continue; // Disconnected or non-standard gamepad
+            for (const [i, gamepad] of navigator.getGamepads().entries()) {
+                if (gamepad == null) {
+                    continue; // Disconnected gamepad
+                } else if (gamepad.mapping != "standard") {
+                    // The gamepad is available, but nonstandard, so we don't actually know how to read it.
+                    // Let's warn once, and not use this gamepad afterwards.
+                    if (!this.inputState.gamepadUnavailableWarned.has(i)) {
+                        this.inputState.gamepadUnavailableWarned.add(i);
+                        console.warn("Your browser does not know the mapping for the %s gamepad (index %d) and we can't use it.", gamepad.id, i);
+                    }
+                    continue;
                 }
 
                 // https://www.w3.org/TR/gamepad/#remapping

--- a/runtimes/web/src/ui/app.ts
+++ b/runtimes/web/src/ui/app.ts
@@ -14,7 +14,7 @@ import { Notifications } from "./notifications";
 
 class InputState {
     gamepad = [0, 0, 0, 0];
-    gamepadUnavailableWarned = new Set<number>;
+    gamepadUnavailableWarned = new Set<string>;
     mouseX = 0;
     mouseY = 0;
     mouseButtons = 0;
@@ -374,14 +374,14 @@ export class App extends LitElement {
                 return; // Browser doesn't support gamepads
             }
 
-            for (const [i, gamepad] of navigator.getGamepads().entries()) {
+            for (const gamepad of navigator.getGamepads()) {
                 if (gamepad == null) {
                     continue; // Disconnected gamepad
                 } else if (gamepad.mapping != "standard") {
                     // The gamepad is available, but nonstandard, so we don't actually know how to read it.
                     // Let's warn once, and not use this gamepad afterwards.
-                    if (!this.inputState.gamepadUnavailableWarned.has(i)) {
-                        this.inputState.gamepadUnavailableWarned.add(i);
+                    if (!this.inputState.gamepadUnavailableWarned.has(gamepad.id)) {
+                        this.inputState.gamepadUnavailableWarned.add(gamepad.id);
                         this.notifications.show("Unsupported gamepad: " + gamepad.id);
                     }
                     continue;


### PR DESCRIPTION
As discussed in #470.

This will warn once per gamepad (so, if somebody connects an nonstandard gamepad and then tries another one, they will get one warning for each). This needs state in form of the `gamepadUnavailableWarned` variable. I didn't really know if it belongs in `InputState` or not, I ended up putting it in but can move it out if you prefer.

Also, this is my first code in TS in my entire life, so caveat emptor :D I did test it on my gamepad and it does seem to work.