### PR TITLE
Update watch.js

### DIFF
--- a/cli/lib/watch.js
+++ b/cli/lib/watch.js
@@ -51,7 +51,7 @@ function start (opts) {
         currentlyBuilding = true;
 
         // console.log("Calling "+buildCommand);
-        const child = spawn(buildCommand, buildParams, {stdio: "inherit"});
+        const child = spawn(buildCommand, buildParams, {stdio: "inherit", shell: true});
         child.on("exit", () => {
             currentlyBuilding = false;
             if (rebuildAfterBuild) {


### PR DESCRIPTION
This change solves the following error:

Error: spawn npm ENOENT

Context: Windows 10 with Node.js 16 installed with nvm using Mingw64/MSYS2 terminal.