### PR TITLE
Fix `w4 watch` with npm on windows

### DIFF
--- a/cli/lib/watch.js
+++ b/cli/lib/watch.js
@@ -14,7 +14,7 @@ function start (opts) {
         buildOutput = "target/wasm32-unknown-unknown/debug/cart.wasm";
 
     } else if (fs.existsSync("package.json")) {
-        buildCommand = "npm";
+        buildCommand = process.platform === "win32"? "npm.cmd": "npm";
         buildParams = ["--silent", "run", "build:debug"];
         buildOutput = "build/cart.wasm";
 


### PR DESCRIPTION
The `w4 watch` command on windows with npm should call the `npm.cmd` file, not `npm`.

Sorry if I did something wrong while creating this pull request, I'm new to GitHub.