### PR TITLE
Set `touch-action: manipulation` to prevent delays on mobile.

### DIFF
--- a/runtimes/web/src/ui/app.ts
+++ b/runtimes/web/src/ui/app.ts
@@ -29,7 +29,7 @@ export class App extends LitElement {
             align-items: center;
             justify-content: center;
 
-            touch-action: none;
+            touch-action: manipulation;
             user-select: none;
             -webkit-user-select: none;
             -webkit-tap-highlight-color: transparent;


### PR DESCRIPTION
When playing on mobile, the first touch of any button will freeze the game for a brief moment. This is very annoying for most games.

Using `touch-action: manipulation` seems to fix the delay issue.