### PR TITLE
Update @giscus/react to v1.1.2 (fixes iframe size)

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@docusaurus/core": "2.0.0-beta.4",
         "@docusaurus/preset-classic": "2.0.0-beta.4",
-        "@giscus/react": "^1.0.0",
+        "@giscus/react": "^1.1.2",
         "@mdx-js/react": "^1.6.21",
         "@svgr/webpack": "^5.5.0",
         "clsx": "^1.1.1",
@@ -2425,14 +2425,10 @@
       }
     },
     "node_modules/@giscus/react": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@giscus/react/-/react-1.0.0.tgz",
-      "integrity": "sha512-KPTGG106meUCRH18IXCZbu4Fdwz3NDnNoesCItIkcYv6wu1ZiWbfeSkuiC8z6sEw+I+JSlXqseRXtjygBy7GJA==",
-      "dependencies": {
-        "iframe-resizer-react": "^1.1.0"
-      },
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@giscus/react/-/react-1.1.2.tgz",
+      "integrity": "sha512-htSAAiTtoHTRE8GqSSkWmT+Iq7LJhtqSmr+HjEC1cXlNd1WeLVZXjnuiIj7+L8DOUnAdfh+1FClN304FVxIcsQ==",
       "peerDependencies": {
-        "prop-types": "^15.7.2",
         "react": "^16 || ^17 || ^18",
         "react-dom": "^16 || ^17 || ^18"
       }
@@ -7598,36 +7594,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/iframe-resizer": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.3.2.tgz",
-      "integrity": "sha512-gOWo2hmdPjMQsQ+zTKbses08mDfDEMh4NneGQNP4qwePYujY1lguqP6gnbeJkf154gojWlBhIltlgnMfYjGHWA==",
-      "engines": {
-        "node": ">=0.8.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/davidjbradshaw/iframe-resizer/blob/master/FUNDING.md"
-      }
-    },
-    "node_modules/iframe-resizer-react": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/iframe-resizer-react/-/iframe-resizer-react-1.1.0.tgz",
-      "integrity": "sha512-FrytSq91AIJaDgE+6uK/Vdd6IR8CrwLoZ6eGmL2qQMPTzF0xlSV2jaSzRRUh5V2fttD7vzl21jvBl97bV40eBw==",
-      "dependencies": {
-        "iframe-resizer": "^4.3.0",
-        "warning": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      },
-      "peerDependencies": {
-        "prop-types": ">=15.7.2",
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/ignore": {
@@ -14672,14 +14638,6 @@
         "node": ">=8.9.0"
       }
     },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "node_modules/watchpack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
@@ -17455,12 +17413,10 @@
       }
     },
     "@giscus/react": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@giscus/react/-/react-1.0.0.tgz",
-      "integrity": "sha512-KPTGG106meUCRH18IXCZbu4Fdwz3NDnNoesCItIkcYv6wu1ZiWbfeSkuiC8z6sEw+I+JSlXqseRXtjygBy7GJA==",
-      "requires": {
-        "iframe-resizer-react": "^1.1.0"
-      }
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@giscus/react/-/react-1.1.2.tgz",
+      "integrity": "sha512-htSAAiTtoHTRE8GqSSkWmT+Iq7LJhtqSmr+HjEC1cXlNd1WeLVZXjnuiIj7+L8DOUnAdfh+1FClN304FVxIcsQ==",
+      "requires": {}
     },
     "@hapi/hoek": {
       "version": "9.2.0",
@@ -21425,20 +21381,6 @@
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
       "requires": {}
-    },
-    "iframe-resizer": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.3.2.tgz",
-      "integrity": "sha512-gOWo2hmdPjMQsQ+zTKbses08mDfDEMh4NneGQNP4qwePYujY1lguqP6gnbeJkf154gojWlBhIltlgnMfYjGHWA=="
-    },
-    "iframe-resizer-react": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/iframe-resizer-react/-/iframe-resizer-react-1.1.0.tgz",
-      "integrity": "sha512-FrytSq91AIJaDgE+6uK/Vdd6IR8CrwLoZ6eGmL2qQMPTzF0xlSV2jaSzRRUh5V2fttD7vzl21jvBl97bV40eBw==",
-      "requires": {
-        "iframe-resizer": "^4.3.0",
-        "warning": "^4.0.3"
-      }
     },
     "ignore": {
       "version": "5.1.8",
@@ -26576,14 +26518,6 @@
         "lodash": "^4.17.21",
         "minimist": "^1.2.5",
         "rxjs": "^6.6.3"
-      }
-    },
-    "warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/site/package.json
+++ b/site/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.4",
     "@docusaurus/preset-classic": "2.0.0-beta.4",
-    "@giscus/react": "^1.0.0",
+    "@giscus/react": "^1.1.2",
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",


### PR DESCRIPTION
Fixes giscus iframe size.

The latest version is 2.2.0, but it has a breaking change so in the meantime this version fixes the iframe sizing issue with minimal impact.