### PR TITLE
Disk import/export/clear

### DIFF
--- a/runtimes/web/src/ui/app.ts
+++ b/runtimes/web/src/ui/app.ts
@@ -581,6 +581,8 @@ export class App extends LitElement {
                         console.error("Error importing disk", error);
                     }
                 }
+
+                app.closeMenu();
             });
 
             reader.readAsArrayBuffer(files[0]);

--- a/runtimes/web/src/ui/app.ts
+++ b/runtimes/web/src/ui/app.ts
@@ -568,10 +568,10 @@ export class App extends LitElement {
                 let disk = new Uint8Array(constants.STORAGE_SIZE);
 
                 disk.set(result);
-                app.runtime.diskBuffer = disk;
+                app.runtime.diskBuffer = disk.buffer;
                 this.runtime.diskSize = result.length;
                 
-                const str = z85.encode(disk);
+                const str = z85.encode(result);
                 try {
                     localStorage.setItem(this.runtime.diskName, str);
                     app.notifications.show("Disk imported");

--- a/runtimes/web/src/ui/app.ts
+++ b/runtimes/web/src/ui/app.ts
@@ -526,6 +526,60 @@ export class App extends LitElement {
         }
     }
 
+    exportGameDisk () {
+        const blob = new Blob([this.runtime.diskBuffer], { type: "application/octet-stream" });
+        const link = document.createElement("a");
+
+        link.style.display = "none";
+        link.href = URL.createObjectURL(new Blob([this.runtime.diskBuffer], { type: "application/octet-stream" }));
+        link.download = "disk.bin";
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+    }
+
+    importGameDisk () {
+        if (this.netplay) {
+            this.notifications.show("Disk loading disabled during netplay");
+            return;
+        }
+
+        const app = this;
+        const input = document.createElement("input");
+
+        input.style.display = "none";
+        input.type = "file";
+        input.accept = ".bin";
+        input.multiple = false;
+
+        input.addEventListener("change", () => {
+            const files = input.files as FileList;
+            let reader = new FileReader();
+            
+            reader.addEventListener("load", () => {
+                let result = new Uint8Array(reader.result as ArrayBuffer, 0, constants.STORAGE_SIZE);
+                app.runtime.diskBuffer = result.buffer;
+                app.notifications.show("Disk loaded");
+            });
+
+            reader.readAsArrayBuffer(files[0]);
+        });
+
+        document.body.appendChild(input);
+        input.click();
+        document.body.removeChild(input);
+    }
+
+    clearGameDisk () {
+        if (this.netplay) {
+            this.notifications.show("Disk clearing disabled during netplay");
+            return;
+        }
+
+        this.runtime.diskBuffer = new ArrayBuffer(constants.STORAGE_SIZE);
+        this.notifications.show("Disk cleared");
+    }
+
     copyNetplayLink () {
         if (!this.netplay) {
             this.netplay = this.createNetplay();

--- a/runtimes/web/src/ui/menu-overlay.ts
+++ b/runtimes/web/src/ui/menu-overlay.ts
@@ -5,11 +5,26 @@ import { map } from 'lit/directives/map.js';
 import { App } from "./app";
 import * as constants from "../constants";
 
+const optionIndex = {
+    CONTINUE: 0,
+    SAVE_STATE: 1,
+    LOAD_STATE: 2,
+    // OPTIONS: null,
+    EXPORT_DISK: 3,
+    IMPORT_DISK: 4,
+    CLEAR_DISK: 5,
+    COPY_NETPLAY_LINK: 6,
+    RESET_CART: 7,
+};
+
 const options = [
     "CONTINUE",
     "SAVE STATE",
     "LOAD STATE",
     // "OPTIONS",
+    "EXPORT DISK",
+    "IMPORT DISK",
+    "CLEAR DISK",
     "COPY NETPLAY URL",
     "RESET CART",
 ];
@@ -102,18 +117,27 @@ export class MenuOverlay extends LitElement {
 
         if (pressedThisFrame & (constants.BUTTON_X | constants.BUTTON_Z)) {
             switch (this.selectedIdx) {
-            case 0:
+            case optionIndex.CONTINUE:
                 break;
-            case 1:
+            case optionIndex.SAVE_STATE:
                 this.app.saveGameState();
                 break;
-            case 2:
+            case optionIndex.LOAD_STATE:
                 this.app.loadGameState();
                 break;
-            case 3:
+            case optionIndex.EXPORT_DISK:
+                this.app.exportGameDisk();
+                break;
+            case optionIndex.IMPORT_DISK:
+                this.app.importGameDisk();
+                break;
+            case optionIndex.CLEAR_DISK:
+                this.app.clearGameDisk();
+                break;
+            case optionIndex.COPY_NETPLAY_LINK:
                 this.app.copyNetplayLink();
                 break;
-            case 4:
+            case optionIndex.RESET_CART:
                 this.app.resetCart();
                 break;
             }

--- a/runtimes/web/src/ui/menu-overlay.ts
+++ b/runtimes/web/src/ui/menu-overlay.ts
@@ -138,7 +138,7 @@ export class MenuOverlay extends LitElement {
         if(this.optionContextHistory.length > 0) {
             const previousContext = this.optionContextHistory.pop() as {context: number, index: number};
 
-            this.app.inputState.gamepad[0] = 0;
+            this.resetInput();
             this.optionContext = previousContext.context;
             this.selectedIdx = previousContext.index;
         }
@@ -150,9 +150,13 @@ export class MenuOverlay extends LitElement {
             index: this.selectedIdx
         });
 
-        this.app.inputState.gamepad[0] = 0;
+        this.resetInput();
         this.optionContext = context;
         this.selectedIdx = index;
+    }
+
+    resetInput () {
+        this.app.inputState.gamepad[0] = 0;
     }
 
     applyInput () {
@@ -202,8 +206,8 @@ export class MenuOverlay extends LitElement {
                         this.app.closeMenu();
                         break;
                     case this.optionIndex.IMPORT_DISK:
+                        this.resetInput();
                         this.app.importGameDisk();
-                        this.app.closeMenu();
                         break;
                     case this.optionIndex.CLEAR_DISK:
                         this.app.clearGameDisk();
@@ -241,11 +245,11 @@ export class MenuOverlay extends LitElement {
     render () {
         return html`
             <div class="menu">
-                <ul data-context="${optionContext.DEFAULT}" style="display:${this.optionContext === optionContext.DEFAULT? "inherit": "none"}">
+                <ul style="display:${this.optionContext === optionContext.DEFAULT? "inherit": "none"}">
                     ${map(options[optionContext.DEFAULT], (option, idx) =>
                         html`<li class="${this.selectedIdx == idx ? "selected" : ""}"}>${option}</li>`)}
                 </ul>
-                <ul data-context="${optionContext.DISK}" style="display:${this.optionContext === optionContext.DISK? "inherit": "none"}">
+                <ul style="display:${this.optionContext === optionContext.DISK? "inherit": "none"}">
                     ${map(options[optionContext.DISK], (option, idx) =>
                         html`<li class="${this.selectedIdx == idx ? "selected" : ""}"}>${option}</li>`)}
                 </ul>


### PR DESCRIPTION
Implementation of disk importing/exporting, as initially suggested on issue #553.

Option indexes for menu overlay were moved in order to be a little easier to reorder them if necessary.

There is now a new "*Disk Options*" submenu, which includes four options:
- **Back:** return to previous menu.
- **Export disk:** download the save data to a binary file, called `<prefix>.disk`.
- **Import disk:** open a file picker, select a `.disk` file, then load a game disk.
- **Clear disk:** clear all contents of game disk.