### PR TITLE
Oval: restore blockiness

### DIFF
--- a/runtimes/native/src/framebuffer.c
+++ b/runtimes/native/src/framebuffer.c
@@ -415,7 +415,7 @@ void w4_framebufferOval (int x, int y, int width, int height) {
 
     // Error increments. Also known as the decision parameters
     int dx = 4 * (1 - a) * b * b;
-    int dy = 4 * (b1 + 2) * a * a;
+    int dy = 4 * (b1 + 1) * a * a;
 
     // Error of 1 step
     int err = dx + dy + b1 * a * a;

--- a/runtimes/web/src/framebuffer.ts
+++ b/runtimes/web/src/framebuffer.ts
@@ -182,7 +182,7 @@ export class Framebuffer {
 
         // Error increments. Also known as the decision parameters
         let dx = 4 * (1 - a) * b * b;
-        let dy = 4 * (b1 + 2) * a * a;
+        let dy = 4 * (b1 + 1) * a * a;
 
         // Error of 1 step
         let err = dx + dy + b1 * a * a;


### PR DESCRIPTION
With the oval fix PR #525 I settled on a less block appearance for the ovals. After it got merged, @ibillingsley commented that they were relying on the blockiness in [their game One Slime Army](https://wasm4.org/play/one-slime-army), and without it the game looks considerably worse. This PR restores the blockiness to the oval drawing.