### PR TITLE
Oval fix asymmetry

### DIFF
--- a/runtimes/native/src/framebuffer.c
+++ b/runtimes/native/src/framebuffer.c
@@ -384,7 +384,7 @@ void w4_framebufferRect (int x, int y, int width, int height) {
 // Javatpoint has a in depth academic explanation that mostly went over my head:
 // https://www.javatpoint.com/computer-graphics-midpoint-ellipse-algorithm
 //
-// Draws the eliipse by "scanning" along the edge in one quadrant, and mirroring
+// Draws the ellipse by "scanning" along the edge in one quadrant, and mirroring
 // the movement for the other four quadrants.
 //
 // There are a lot of details to get correct while implementing this algorithm,
@@ -402,12 +402,11 @@ void w4_framebufferOval (int x, int y, int width, int height) {
     uint8_t strokeColor = (dc1 - 1) & 0x3;
     uint8_t fillColor = (dc0 - 1) & 0x3;
 
-    int a = width;
-    int b = height;
-    int b1 = (height + 1) % 2; // Compensates for precision loss when dividing
+    int a = width - 1;
+    int b = height - 1;
+    int b1 = b % 2; // Compensates for precision loss when dividing
 
-    int north = y;
-    north += b / 2; // Precision loss here
+    int north = y + height / 2; // Precision loss here
     int west = x;
     int east = x + width - 1;
     int south = north - b1; // Compensation here. Moves the bottom line up by

--- a/runtimes/web/src/framebuffer.ts
+++ b/runtimes/web/src/framebuffer.ts
@@ -151,7 +151,7 @@ export class Framebuffer {
     // Javatpoint has a in depth academic explanation that mostly went over my head:
     // https://www.javatpoint.com/computer-graphics-midpoint-ellipse-algorithm
     //
-    // Draws the eliipse by "scanning" along the edge in one quadrant, and mirroring
+    // Draws the ellipse by "scanning" along the edge in one quadrant, and mirroring
     // the movement for the other four quadrants.
     //
     // There are a lot of details to get correct while implementing this algorithm,
@@ -169,12 +169,11 @@ export class Framebuffer {
         const strokeColor = (dc1 - 1) & 0x3;
         const fillColor = (dc0 - 1) & 0x3;
 
-        let a = width;
-        const b = height;
-        let b1 = (height + 1) % 2; // Compensates for precision loss when dividing
+        let a = width - 1;
+        const b = height - 1;
+        let b1 = b % 2; // Compensates for precision loss when dividing
 
-        let north = y;
-        north += Math.floor(b / 2); // Precision loss here
+        let north = y + Math.floor(height / 2); // Precision loss here
         let west = x;
         let east = x + width - 1;
         let south = north - b1; // Compensation here. Moves the bottom line up by


### PR DESCRIPTION
Follow-up to #561.  
I believe I figured out the discrepancy with drawOval compared to the [TIC-80 version](https://github.com/nesbox/TIC-80/blob/e58c583ea7b000446971a311d5469d0b7d90531b/src/core/draw.c#L497) used as reference.

Their parameters are an inclusive bounding box. When calculating `a` and `b` from `width` and `height` we need to subtract `1` to match their algorithm. This seems to correct the asymmetry we were seeing at certain sizes:  
![wasm4-screenshot-1](https://user-images.githubusercontent.com/1782216/189510692-4fdb1294-1d30-4932-a0f7-1ed4e500ed15.png)

@desttinghim fyi