### PR TITLE
Add `runner` to Rust's `./.cargo/config.toml`

### DIFF
--- a/cli/assets/templates/rust/.cargo/config.toml
+++ b/cli/assets/templates/rust/.cargo/config.toml
@@ -2,6 +2,7 @@
 target = "wasm32-unknown-unknown"
 
 [target.wasm32-unknown-unknown]
+runner = "w4 run-native"
 rustflags = [
     # Import memory from WASM-4
     "-C", "link-arg=--import-memory",


### PR DESCRIPTION
This change allows `cargo run` to run the game in the native runtime automatically, instead of `cargo build & w4 run-native ./target/wasm32-unknown-unknown/debug/cart.wasm`