### PR TITLE
Improve Rust template to allow drawing buttons, resolving issue #590

### DIFF
--- a/cli/assets/templates/rust/src/wasm4.rs
+++ b/cli/assets/templates/rust/src/wasm4.rs
@@ -135,7 +135,7 @@ extern "C" {
 }
 
 /// Draws text using the built-in system font.
-pub fn text<T: AsRef<str>>(text: T, x: i32, y: i32) {
+pub fn text<T: AsRef<[u8]>>(text: T, x: i32, y: i32) {
     let text_ref = text.as_ref();
     unsafe { extern_text(text_ref.as_ptr(), text_ref.len(), x, y) }
 }

--- a/site/docs/guides/text.md
+++ b/site/docs/guides/text.md
@@ -81,7 +81,7 @@ It's possible to print one of these characters by escaping it's charcode.
 | Key         | Escape Character |
 |-------------|------------------|
 | X button    | `\x80`           |
-| Y button    | `\x81`           |
+| Z button    | `\x81`           |
 | Left arrow  | `\x84`           |
 | Right arrow | `\x85`           |
 | Up arrow    | `\x86`           |
@@ -96,9 +96,65 @@ We could use those as instructions for our games!
 w4.text("Press \x86 to jump!", 10, 10);
 ```
 
+```c
+// Press UP to jump!
+text("Press \x86 to jump!", 10, 10);
+```
+
+```d
+// Press UP to jump!
+w4.text("Press \x86 to jump!", 10, 10);
+```
+
+```go
+// Press UP to jump!
+w4.Text("Press \x86 to jump!", 10, 10)
+```
+
+```lua
+-- Press UP to jump!
+text("Press \x86 to jump!", 10, 10)
+```
+
+```nim
+# Press UP to jump!
+text("Press \x86 to jump!", 10, 10)
+```
+
+```odin
+// Press UP to jump!
+w4.text("Press \x86 to jump!", 10, 10)
+```
+
+```porth
+import proc text int int ptr in end
+
+// Press UP to jump!
+10 10 "Press \x86 to jump!"c text
+```
+
+```roland
+// Press UP to jump!
+text("Press \x86 to jump!", 10, 10);
+```
+
 ```rust
 // Press UP to jump!
 text(b"Press \x86 to jump!", 10, 10);
+```
+
+```wasm
+(import "env" "text" (func $text (param i32 i32 i32)))
+
+;; Press UP to jump!
+(data (i32.const 0x2000) "Press \86 to jump!\00")
+
+(call $text (i32.const 0x2000) (i32.const 10) (i32.const 10))
+```
+
+```zig
+// Press UP to jump!
+w4.text("Press \x86 to jump!", 10, 10);
 ```
 
 </MultiLanguageCode>

--- a/site/docs/reference/functions.md
+++ b/site/docs/reference/functions.md
@@ -85,11 +85,10 @@ The font is 8x8 pixels per character.
 `DRAW_COLORS` color 1 is used as the text color, `DRAW_COLORS` color 2 is used as the background color.
 
 :::note String Encoding
-By default, `str` is expected to be a `\0` terminated ASCII string. There are 2 additional variants
-of this function for passing unterminated UTF-8 and UTF-16 strings along with a byte length.
-
-* `textUtf8 (strUtf8, byteLength, x, y)`
-* `textUtf16 (strUtf16, byteLength, x, y)`
+By default, `str` is expected to be a `\0` terminated ASCII string.
+This means bytes `0x80-0xFF` are treated as individual characters, even in programming languages where strings are normally UTF-8 encoded.
+No terminating `\0` is needed in those languages.
+In languages where all strings are UTF-16, `str` must only contain characters up to U+00FF and no `\0` is needed.
 :::
 
 ## Sound
@@ -175,11 +174,9 @@ Called every frame, about 60 times per second.
 Prints a message to the debug console.
 
 :::note String Encoding
-By default, `str` is expected to be a `\0` terminated ASCII string. There are 2 additional variants
-of this function for passing unterminated UTF-8 and UTF-16 strings along with a byte length.
-
-* `traceUtf8 (strUtf8, byteLength)`
-* `traceUtf16 (strUtf16, byteLength)`
+By default, `str` is expected to be a `\0` terminated ASCII string.
+In programming languages with UTF-8 or UTF-16 encoded string literals,
+that encoding is used instead and no `\0` is needed.
 :::
 
 ### `tracef (fmt, stackPtr)`


### PR DESCRIPTION
This pull request resolves issue #590. It is an alternative/predecessor to my earlier (and more involved) pull request #528.

Unlike the other programming languages supported by WASM-4, Rust enforces that its strings (`String`, `&str` and string literals) are valid UTF-8, which prevents game developers from using `\x80` in a string literal to draw the X button. A solution would be using byte strings:
```rust
text(b"Press \x80 to jump!", 10, 10);
```
In fact pull request #573 added this code sample, but it does not compile with v2.5.3 (see #590). I had somehow convinced myself that allowing byte strings would prevent normal string literals (e.g. just `text("Hello world!", 10, 10)`) from compiling, which would have been a big loss in ergonomics for Rust users. That's why I had originally discarded this option. However after commenting on #590 I realized that `str` implements `AsRef<[u8]>`, which means we can use regular strings as long as they only contain US-ASCII, and use byte string literals for special occassions.

This change only affects new Rust crates and is completely backwards compatible.