### PR TITLE
Add tracef to native runtime

### DIFF
--- a/runtimes/web/src/runtime.ts
+++ b/runtimes/web/src/runtime.ts
@@ -307,6 +307,9 @@ export class Runtime {
                     output += this.data.getFloat64(argPtr, true);
                     argPtr += 8;
                     break;
+                default: // unknown
+                    output += "%" + String.fromCharCode(ch);
+                    break;
                 }
             } else {
                 output += String.fromCharCode(ch);


### PR DESCRIPTION
**Updated 2024-04-18!**

Using `vprintf` directly would segfault on `%s` because it would try to read the pointer from host memory rather than WASM memory.

Code is mostly ported from web runtime.

## Test code:
```c
#include "wasm4.h"
void start() {
	tracef("|A|%%|%c|%d|0x%x|%s|%f|%u|%d|", 'B', 123, 0xcafe, "string", 1.23, 456, 789);
}
```

## Results
```diff
Old:
- Web:    |A|%|B|123|0xcafe|string|1.23||456|
- Native: |A|%%|%c|%d|0x%x|%s|%f|%u|%d|
New:
+ Web:    |A|%|B|123|0xcafe|string|1.23|%u|456|
+ Native: |A|%|B|123|0xcafe|string|1.23|%u|456|
```

The web runtime was also modified to show unrecognized specifiers as they are rather than remove them (see `%u`).
