### PR TITLE
Remove text null-terminator discrepancy

### DIFF
--- a/runtimes/native/src/framebuffer.c
+++ b/runtimes/native/src/framebuffer.c
@@ -500,7 +500,7 @@ void w4_framebufferLine (int x1, int y1, int x2, int y2) {
 }
 
 void w4_framebufferText (const uint8_t* str, int x, int y) {
-    for (int currentX = x; *str != '\0'; ++str) {
+    for (int currentX = x; *str; ++str) {
         if (*str == 10) {
             y += 8;
             currentX = x;
@@ -513,7 +513,7 @@ void w4_framebufferText (const uint8_t* str, int x, int y) {
 }
 
 void w4_framebufferTextUtf8 (const uint8_t* str, int byteLength, int x, int y) {
-    for (int currentX = x; byteLength > 0; ++str, --byteLength) {
+    for (int currentX = x; byteLength > 0 && *str; ++str, --byteLength) {
         if (*str == 10) {
             y += 8;
             currentX = x;
@@ -526,7 +526,7 @@ void w4_framebufferTextUtf8 (const uint8_t* str, int byteLength, int x, int y) {
 }
 
 void w4_framebufferTextUtf16 (const uint16_t* str, int byteLength, int x, int y) {
-    for (int currentX = x; byteLength > 0; ++str, byteLength -= 2) {
+    for (int currentX = x; byteLength > 0 && *str; ++str, byteLength -= 2) {
         uint16_t c = w4_read16LE(str);
         if (c == 10) {
             y += 8;


### PR DESCRIPTION
On web, calls to `textUtf8` and `textUtf16` [will stop at a null-terminator](https://github.com/aduros/wasm4/blob/9149980e0f8122fcfa05445baf2d253d991787dc/runtimes/web/src/framebuffer.ts#L277) even when [given a length](https://github.com/aduros/wasm4/blob/main/runtimes/web/src/runtime.ts#L198). Native does not do this, but instead will happily try to print the null character despite there being no font glyph for it.

This commit changes native to also stop at null-terminators to remove the discrepancy between the runtimes.

We could also instead change web to print out the null characters, but that doesn't serve any purpose and is less likely to be what a game creator wants.