### PR TITLE
Initial changes to support easy hosting of site and netplay connection server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:16.19.1-alpine3.17 as web
+
+RUN npm i -g rimraf typescript
+WORKDIR /app
+COPY . .
+
+WORKDIR /app/devtools/web
+
+RUN npm ci
+RUN npm run build
+
+WORKDIR /app/runtimes/web
+
+RUN npm ci
+RUN npm run build
+
+FROM node:16.19.1-alpine3.17
+
+WORKDIR /app
+COPY . .
+WORKDIR /app/site
+
+COPY --from=web /app/runtimes/web/dist/slim /app/site/static/embed
+
+RUN npm ci
+RUN npm run build
+
+EXPOSE 3030
+ENTRYPOINT ["npm", "run", "serve"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.9"
+services:
+  web:
+    image: wasm4:dev
+    deploy:
+      replicas: 1
+      resources:
+        limits:
+          memory: 500M
+      restart_policy:
+        condition: on-failure
+    ports:
+      - "3030:3030"
+  wss:
+    image: wasm4-wss:dev
+    deploy:
+      replicas: 1
+      resources:
+        limits:
+          memory: 500M
+      restart_policy:
+        condition: on-failure
+    ports:
+      - "4445:4445"

--- a/runtimes/web/src/netplay/index.ts
+++ b/runtimes/web/src/netplay/index.ts
@@ -12,6 +12,8 @@ import { MovingAverage } from "./moving-average";
  */
 export const DEV_NETPLAY = false;
 
+const HOSTNAME = "wasm4.org";
+
 const SIMULATE_LAG = false;
 
 const MAX_OUTBOUND_INPUTS = 20;
@@ -249,7 +251,7 @@ export class Netplay {
     }
 
     getInviteLink (): string {
-        return `https://wasm4.org/netplay/#${this.peerMgr.localPeerId}`;
+        return `https://${HOSTNAME}/netplay/#${this.peerMgr.localPeerId}`;
     }
 
     close () {

--- a/runtimes/web/src/netplay/peer-manager.ts
+++ b/runtimes/web/src/netplay/peer-manager.ts
@@ -1,5 +1,7 @@
 import { DEV_NETPLAY } from "./index";
 
+const HOSTNAME = "aduros.com";
+
 /** WebRTC signaling messages. */
 type Message = OfferMessage | AnswerMessage | CandidateMessage | AbortMessage;
 
@@ -41,7 +43,7 @@ class SignalClient {
     private readonly bufferedOutput: string[] = [];
 
     constructor (localPeerId: string, onMessage: (source: string, message: Message) => void) {
-        this.socket = new WebSocket(`wss://aduros.com/webrtc-signal-server/?peerId=${encodeURIComponent(localPeerId)}`);
+        this.socket = new WebSocket(`wss://${HOSTNAME}/webrtc-signal-server/?peerId=${encodeURIComponent(localPeerId)}`);
         this.socket.addEventListener("message", event => {
             const { source, message } = JSON.parse(event.data);
             // console.log(`Received ${message.type} message from ${source}`);

--- a/runtimes/web/webrtc-signal-server/Dockerfile
+++ b/runtimes/web/webrtc-signal-server/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:16.19.1-alpine3.17 as web
+
+RUN npm i -g rimraf typescript
+WORKDIR /app
+COPY . .
+
+RUN npm ci
+
+EXPOSE 4445
+ENTRYPOINT ["./start"]


### PR DESCRIPTION
If the idea of making it easy for others to host the site/netplay server is appealing, I could write up documentation and flesh this out more. I don't expect or want this PR to be accepted in its current state; I'm looking for feedback on whether this is a project goal or not. 

I made some basic changes that allow users to easily host the site and netplay server that connects peers together. This includes adding a Dockerfile and example docker-compose file. I wasn't really able to find any documentation about this side of WASM-4, and if the aduros.com or wasm4.org websites go down then WASM-4 netplay stops working unless there are other signal servers being run.

These changes were the bare minimum I needed to get things working in a testing environment. I have another branch where I removed more of the site and made further changes needed for me to re-host, but I don't think any of that is useful upstream. There's plenty of things to improve here: not running the site from "docusaurus serve" in the Dockerfile and making it easier to configure the new "$HOSTNAME" are obvious places to start and there are several other changes that would make this more generally useful.