### PR TITLE
Fix #417

### DIFF
--- a/runtimes/native/src/backend/wasm_wasm3.c
+++ b/runtimes/native/src/backend/wasm_wasm3.c
@@ -151,7 +151,7 @@ static m3ApiRawFunction (traceUtf16) {
 static m3ApiRawFunction (tracef) {
     m3ApiGetArgMem(const char*, str);
     m3ApiGetArgMem(const void*, stack);
-    w4_runtimeTracef(str, stack);
+    w4_runtimeTracef(str, stack, _mem);
     m3ApiSuccess();
 }
 

--- a/runtimes/native/src/backend/wasm_wasm3.c
+++ b/runtimes/native/src/backend/wasm_wasm3.c
@@ -151,7 +151,7 @@ static m3ApiRawFunction (traceUtf16) {
 static m3ApiRawFunction (tracef) {
     m3ApiGetArgMem(const char*, str);
     m3ApiGetArgMem(const void*, stack);
-    w4_runtimeTracef(str, stack, _mem);
+    w4_runtimeTracef(str, stack);
     m3ApiSuccess();
 }
 

--- a/runtimes/native/src/runtime.c
+++ b/runtimes/native/src/runtime.c
@@ -14,6 +14,7 @@
 #define HEIGHT 160
 
 #define SYSTEM_PRESERVE_FRAMEBUFFER 1
+#define SYSTEM_STANDARD_TRACING 4
 
 typedef struct {
     uint8_t _padding[4];
@@ -171,7 +172,7 @@ static unsigned align(unsigned v, unsigned a) {
     return (v + a - 1) & ~(a - 1);
 }
 
-void w4_runtimeTracef (const uint8_t* fmt, const uint8_t * stk, const uint8_t * mem) {
+void w4_runtimeTracef (const uint8_t* fmt, const uint8_t * stk) {
     char out[256];
     char buf[256];
     size_t sofar = 0;
@@ -206,7 +207,7 @@ void w4_runtimeTracef (const uint8_t* fmt, const uint8_t * stk, const uint8_t * 
             si += 8;
             break;
         case 's':
-            sofar += snprintf(out+sofar, sizeof(out)-sofar, fb, mem+*(int32_t*)(stk+si));
+  	    sofar += snprintf(out+sofar, sizeof(out)-sofar, fb, ((uint8_t*)memory)+*(int32_t*)(stk+si));
             si += 4;
             break;
         default:
@@ -214,7 +215,10 @@ void w4_runtimeTracef (const uint8_t* fmt, const uint8_t * stk, const uint8_t * 
         }
         s = strsep(&ctx, "%");
     }
-    fputs(out, stdout);
+    if (memory->systemFlags & SYSTEM_STANDARD_TRACING)
+      fputs(out, stdout);
+    else
+      puts(out);
 }
 
 void w4_runtimeUpdate () {

--- a/runtimes/native/src/runtime.h
+++ b/runtimes/native/src/runtime.h
@@ -44,7 +44,7 @@ int w4_runtimeDiskw (const uint8_t* src, int size);
 void w4_runtimeTrace (const uint8_t* str);
 void w4_runtimeTraceUtf8 (const uint8_t* str, int byteLength);
 void w4_runtimeTraceUtf16 (const uint16_t* str, int byteLength);
-void w4_runtimeTracef (const uint8_t* str, const uint8_t* stack, const uint8_t* mem);
+void w4_runtimeTracef (const uint8_t* str, const uint8_t* stack);
 
 void w4_runtimeUpdate ();
 

--- a/runtimes/native/src/runtime.h
+++ b/runtimes/native/src/runtime.h
@@ -44,7 +44,7 @@ int w4_runtimeDiskw (const uint8_t* src, int size);
 void w4_runtimeTrace (const uint8_t* str);
 void w4_runtimeTraceUtf8 (const uint8_t* str, int byteLength);
 void w4_runtimeTraceUtf16 (const uint16_t* str, int byteLength);
-void w4_runtimeTracef (const uint8_t* str, const void* stack);
+void w4_runtimeTracef (const uint8_t* str, const uint8_t* stack, const uint8_t* mem);
 
 void w4_runtimeUpdate ();
 


### PR DESCRIPTION
This is my attempt to fix `tracef` for the wasm3 runtime. Looks convoluted, and it is, but it's just that implementing this portably is a PITA.