### PR TITLE
Improve piping support and add `-` alias.

### DIFF
--- a/runtimes/native/src/backend/main.c
+++ b/runtimes/native/src/backend/main.c
@@ -153,7 +153,31 @@ int main (int argc, const char* argv[]) {
         strcat(diskPath, DISK_FILE_EXT);
         loadDiskFile(&disk, diskPath);
 
-    } else {
+    } else if (!strcmp(argv[1], "-") || !strcmp(argv[1], "/dev/stdin")) {
+        size_t bufsize = 1024;
+        cartBytes = malloc(bufsize);
+        cartLength = 0;
+        int c;
+
+        while((c = getc(stdin)) != EOF) {
+            cartBytes[cartLength++] = c;
+            if(cartLength == bufsize) {
+                if (cartLength >= 64 * 1024) {
+                    fprintf(stderr, "Error, overflown cartridge size limit of 64 KB\n");
+                    return 1;
+                }
+
+                bufsize *= 2;
+                cartBytes = realloc(cartBytes, bufsize);
+
+                if(!cartBytes) {
+                    fprintf(stderr, "Error reallocating cartridge buffer\n");
+                    return 1;
+                }
+            }
+        }
+    }
+    else {
         FILE* file = fopen(argv[1], "rb");
         if (file == NULL) {
             fprintf(stderr, "Error opening %s\n", argv[1]);


### PR DESCRIPTION
- [Fixes `w4 run` piping](https://github.com/aduros/wasm4/commit/1d1f2b7c6b1da2bce2dacdf16da64d12f0e0afc8)
   - Waits for the end of the input instead of starting the server automatically without the cart.
- [Adds piping support to the native backend](https://github.com/aduros/wasm4/commit/19074ad63358cd8a72cd941623e4477c6bd024dd)
   - Avaiable from both the executable and the `w4 -run-native` cli option
- Adds `-` as an alias for `/dev/stdin` for both backends.
   - Both should work on windows, but was not tested