### PR TITLE
General improvements to the native runtime

### DIFF
--- a/runtimes/native/src/backend/main.c
+++ b/runtimes/native/src/backend/main.c
@@ -8,6 +8,7 @@
 #include "../runtime.h"
 #include "../wasm.h"
 #include "../window.h"
+#include "../util.h"
 
 #if defined(_WIN32)
 #include <windows.h>
@@ -139,13 +140,13 @@ int main (int argc, const char* argv[]) {
         footer.title[sizeof(footer.title)-1] = '\0';
         title = footer.title;
 
-        cartBytes = malloc(footer.cartLength);
+        cartBytes = xmalloc(footer.cartLength);
         fseek(file, -sizeof(FileFooter) - footer.cartLength, SEEK_END);
         cartLength = fread(cartBytes, 1, footer.cartLength, file);
         fclose(file);
 
         // Look for disk file
-        diskPath = malloc(strlen(argv[0]) + sizeof(DISK_FILE_EXT));
+        diskPath = xmalloc(strlen(argv[0]) + sizeof(DISK_FILE_EXT));
         strcpy(diskPath, argv[0]);
 #ifdef _WIN32
         trimFileExtension(diskPath); // Trim .exe on Windows
@@ -155,7 +156,7 @@ int main (int argc, const char* argv[]) {
 
     } else if (!strcmp(argv[1], "-") || !strcmp(argv[1], "/dev/stdin")) {
         size_t bufsize = 1024;
-        cartBytes = malloc(bufsize);
+        cartBytes = xmalloc(bufsize);
         cartLength = 0;
         int c;
 
@@ -168,7 +169,7 @@ int main (int argc, const char* argv[]) {
                 }
 
                 bufsize *= 2;
-                cartBytes = realloc(cartBytes, bufsize);
+                cartBytes = xrealloc(cartBytes, bufsize);
 
                 if(!cartBytes) {
                     fprintf(stderr, "Error reallocating cartridge buffer\n");
@@ -188,12 +189,12 @@ int main (int argc, const char* argv[]) {
         cartLength = ftell(file);
         fseek(file, 0, SEEK_SET);
 
-        cartBytes = malloc(cartLength);
+        cartBytes = xmalloc(cartLength);
         cartLength = fread(cartBytes, 1, cartLength, file);
         fclose(file);
 
         // Look for disk file
-        diskPath = malloc(strlen(argv[1]) + sizeof(DISK_FILE_EXT));
+        diskPath = xmalloc(strlen(argv[1]) + sizeof(DISK_FILE_EXT));
         strcpy(diskPath, argv[1]);
         trimFileExtension(diskPath); // Trim .wasm
         strcat(diskPath, DISK_FILE_EXT);

--- a/runtimes/native/src/backend/main_libretro.c
+++ b/runtimes/native/src/backend/main_libretro.c
@@ -8,6 +8,7 @@
 #include "../apu.h"
 #include "../runtime.h"
 #include "../wasm.h"
+#include "../util.h"
 
 #define AUDIO_BUFFER_FRAMES_CALLBACK 256
 #define AUDIO_BUFFER_FRAMES_PER_VIDEO_FRAME 735
@@ -276,7 +277,7 @@ bool retro_load_game (const struct retro_game_info* game) {
         wasmCopy = false;
     } else {
         // Otherwise we need to manage our own copy
-        wasmData = malloc(wasmLength);
+        wasmData = xmalloc(wasmLength);
         wasmCopy = true;
         memcpy(wasmData, game->data, wasmLength);
     }

--- a/runtimes/native/src/framebuffer.c
+++ b/runtimes/native/src/framebuffer.c
@@ -427,13 +427,13 @@ void w4_framebufferOval (int x, int y, int width, int height) {
         drawPointUnclipped(strokeColor, west, north); /*   II. Quadrant    */
         drawPointUnclipped(strokeColor, west, south); /*   III. Quadrant   */
         drawPointUnclipped(strokeColor, east, south); /*   IV. Quadrant    */
-        const start = west + 1;
-        const len = east - start;
+        const int start = west + 1;
+        const int len = east - start;
         if (dc0 != 0 && len > 0) { // Only draw fill if the length from west to east is not 0
             drawHLineUnclipped(fillColor, start, north, east); /*   I and III. Quadrant */
             drawHLineUnclipped(fillColor, start, south, east); /*  II and IV. Quadrant */
         }
-        const err2 = 2 * err;
+        const int err2 = 2 * err;
         if (err2 <= dy) {
             // Move vertical scan
             north += 1;

--- a/runtimes/native/src/runtime.c
+++ b/runtimes/native/src/runtime.c
@@ -55,7 +55,7 @@ void w4_runtimeInit (uint8_t* memoryBytes, w4_Disk* diskBytes) {
     w4_write16LE(&memory->mouseY, 0x7fff);
 
     w4_apuInit();
-    w4_framebufferInit(&memory->drawColors, memory->framebuffer);
+    w4_framebufferInit(memory->drawColors, memory->framebuffer);
 }
 
 void w4_runtimeSetGamepad (int idx, uint8_t gamepad) {

--- a/runtimes/native/src/runtime.c
+++ b/runtimes/native/src/runtime.c
@@ -14,6 +14,7 @@
 
 #define SYSTEM_PRESERVE_FRAMEBUFFER 1
 
+#pragma pack(1)
 typedef struct {
     uint8_t _padding[4];
     uint32_t palette[4];
@@ -27,6 +28,7 @@ typedef struct {
     uint8_t framebuffer[WIDTH*HEIGHT>>2];
     uint8_t _user[58976];
 } Memory;
+#pragma pack()
 
 typedef struct {
     Memory memory;

--- a/runtimes/native/src/util.c
+++ b/runtimes/native/src/util.c
@@ -1,8 +1,27 @@
 #include "util.h"
+#include <stdlib.h>
+#include <stdio.h>
 
 #if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #    define W4_BIG_ENDIAN
 #endif
+
+void* xmalloc(size_t size) {
+    void* ptr = malloc(size);
+    if (ptr == NULL) {
+        fputs("Allocation failed.\n", stderr);
+        abort();
+    }
+    return ptr;
+}
+
+void* xrealloc(void* ptr, size_t size) {
+    ptr = realloc(ptr, size);
+    if (ptr == NULL) {
+        fputs("Allocation failed.\n", stderr);
+        abort();
+    }
+}
 
 uint16_t bswap16(uint16_t x) {
     return ((( x  >> 8 ) & 0xffu ) | (( x  & 0xffu ) << 8 ));

--- a/runtimes/native/src/util.h
+++ b/runtimes/native/src/util.h
@@ -1,6 +1,11 @@
 #pragma once
 
 #include <stdint.h>
+#include <stddef.h>
+
+// Safe versions of malloc and realloc that abort on failure, and never return null.
+void* xmalloc(size_t size);
+void* xrealloc(void* ptr, size_t size);
 
 uint16_t w4_read16LE (const uint16_t* ptr);
 uint32_t w4_read32LE (const uint32_t* ptr);


### PR DESCRIPTION
These commits fix some potential null pointer dereferences, squash some compiler warnings, and defensively add a `#pragma pack(1)` to the memory layout struct.