### PR TITLE
Remove duplicate instructions in web and native runtime's `oval()`

### DIFF
--- a/runtimes/native/src/framebuffer.c
+++ b/runtimes/native/src/framebuffer.c
@@ -413,27 +413,34 @@ void w4_framebufferOval (int x, int y, int width, int height) {
                             // one (overlapping the top line) for even heights
 
     // Error increments. Also known as the decision parameters
-    int dx = 4 * (1 - a) * b * b;
-    int dy = 4 * (b1 + 1) * a * a;
+    const int a2 = a * a;
+    const int b2 = b * b;
+    
+    int dx = 4 * (1 - a) * b2;
+    int dy = 4 * (b1 + 1) * a2;
 
     // Error of 1 step
-    int err = dx + dy + b1 * a * a;
+    int err = dx + dy + b1 * a2;
 
-    a *= 8 * a;
-    b1 = 8 * b * b;
+    a = 8 * a2;
+    b1 = 8 * b2;
 
     do {
         drawPointUnclipped(strokeColor, east, north); /*   I. Quadrant     */
         drawPointUnclipped(strokeColor, west, north); /*   II. Quadrant    */
         drawPointUnclipped(strokeColor, west, south); /*   III. Quadrant   */
         drawPointUnclipped(strokeColor, east, south); /*   IV. Quadrant    */
+
         const int start = west + 1;
         const int len = east - start;
+
         if (dc0 != 0 && len > 0) { // Only draw fill if the length from west to east is not 0
             drawHLineUnclipped(fillColor, start, north, east); /*   I and III. Quadrant */
             drawHLineUnclipped(fillColor, start, south, east); /*  II and IV. Quadrant */
         }
+
         const int err2 = 2 * err;
+
         if (err2 <= dy) {
             // Move vertical scan
             north += 1;
@@ -441,7 +448,8 @@ void w4_framebufferOval (int x, int y, int width, int height) {
             dy += a;
             err += dy;
         }
-        if (err2 >= dx || 2 * err > dy) {
+
+        if (err2 >= dx || err2 > dy) {
             // Move horizontal scan
             west += 1;
             east -= 1;

--- a/runtimes/web/src/framebuffer.ts
+++ b/runtimes/web/src/framebuffer.ts
@@ -179,28 +179,35 @@ export class Framebuffer {
         let south = north - b1; // Compensation here. Moves the bottom line up by
                                 // one (overlapping the top line) for even heights
 
+        const a2 = a * a;
+        const b2 = b * b;
+
         // Error increments. Also known as the decision parameters
-        let dx = 4 * (1 - a) * b * b;
-        let dy = 4 * (b1 + 1) * a * a;
+        let dx = 4 * (1 - a) * b2;
+        let dy = 4 * (b1 + 1) * a2;
 
         // Error of 1 step
-        let err = dx + dy + b1 * a * a;
+        let err = dx + dy + b1 * a2;
 
-        a *= 8 * a;
-        b1 = 8 * b * b;
+        a = 8 * a2;
+        b1 = 8 * b2;
 
         do {
             this.drawPointUnclipped(strokeColor, east, north); /*   I. Quadrant     */
             this.drawPointUnclipped(strokeColor, west, north); /*   II. Quadrant    */
             this.drawPointUnclipped(strokeColor, west, south); /*   III. Quadrant   */
             this.drawPointUnclipped(strokeColor, east, south); /*   IV. Quadrant    */
+
             const start = west + 1;
             const len = east - start;
+
             if (dc0 !== 0 && len > 0) { // Only draw fill if the length from west to east is not 0
                 this.drawHLineUnclipped(fillColor, start, north, east); /*   I and III. Quadrant */
                 this.drawHLineUnclipped(fillColor, start, south, east); /*  II and IV. Quadrant */
             }
+
             const err2 = 2 * err;
+
             if (err2 <= dy) {
                 // Move vertical scan
                 north += 1;
@@ -208,7 +215,8 @@ export class Framebuffer {
                 dy += a;
                 err += dy;
             }
-            if (err2 >= dx || 2 * err > dy) {
+
+            if (err2 >= dx || err2 > dy) {
                 // Move horizontal scan
                 west += 1;
                 east -= 1;


### PR DESCRIPTION
While fixing [wasmstation](https://github.com/wasmstation/wasmstation)'s oval() I found that there are quite a few little "twice-defined values" in this function.

This PR fixes:
 - `err2` being calculated twice.
 - `b * b` and `a * a` being calculated five separate times.
 - `a` being modified in a way that's inconsistent with how `b1` is modified next to it.
 
 in both the web and native runtimes.
 
 In theory, my changing `err * 2 > dy` to `err2 > dy` would result in different behavior because `err` may be modified after `err2` is defined. In practice, I haven't seen this happen. I ran both the web and native runtimes with this change through [wasm4-test-cart](https://github.com/JerwuQu/wasm4-test-cart/) and there was no difference in all **~1500** oval() assertions.

This change should create identical ovals with fewer operations.