### PR TITLE
Make the invite link work for html bundles

### DIFF
--- a/runtimes/web/src/netplay/index.ts
+++ b/runtimes/web/src/netplay/index.ts
@@ -249,7 +249,14 @@ export class Netplay {
     }
 
     getInviteLink (): string {
-        var url = new URL(window.location.href);
+        const loc = window.location;
+        if (loc.protocol == "file:"
+            || loc.hostname == "localhost"
+            || loc.hostname == "127.0.0.1"
+            || loc.hostname == "wasm4.org") {
+            return `https://wasm4.org/netplay/#${this.peerMgr.localPeerId}`;
+        }
+        var url = new URL(loc.href);
         url.searchParams.set('netplay', this.peerMgr.localPeerId);
         return url.href;
     }

--- a/runtimes/web/src/netplay/index.ts
+++ b/runtimes/web/src/netplay/index.ts
@@ -249,7 +249,9 @@ export class Netplay {
     }
 
     getInviteLink (): string {
-        return `https://wasm4.org/netplay/#${this.peerMgr.localPeerId}`;
+        var url = new URL(window.location.href);
+        url.searchParams.set('netplay', this.peerMgr.localPeerId);
+        return url.href;
     }
 
     close () {


### PR DESCRIPTION
### What
Make the invite link the same URL that the game is being displayed from with the netplay peer ID parameter, instead of a link to wasm4.org/netplay.

### Why
When bundling wasm4 games as HTML, it's an odd user experience that invite links take players off to another website.