### PR TITLE
Detect mobile with hover: none

### DIFF
--- a/runtimes/web/src/ui/virtual-gamepad.ts
+++ b/runtimes/web/src/ui/virtual-gamepad.ts
@@ -28,7 +28,7 @@ export class VirtualGamepad extends LitElement {
         :host {
             display: none;
         }
-        @media (pointer: coarse) {
+        @media (hover: none) {
             :host {
                 display: inherit;
             }


### PR DESCRIPTION
### What
Detect mobile with hover: none instead of pointer: coarse.

### Why
pointer: coarse is not a reliable way to identify mobile touch devices. Android Pixel 7 devices report themselves as pointer: fine.