### PR TITLE
Fix the annotations in the Zig Snake tutorial

### DIFF
--- a/site/docs/tutorials/snake/collision-detection.md
+++ b/site/docs/tutorials/snake/collision-detection.md
@@ -725,7 +725,7 @@ What you do, is up to you. You could stop the game and show the score. Or you co
 <Page value="zig">
 
 ```zig
-    pub fn isDead(this: @This()) bool {
+    pub fn isDead(this: *@This()) bool {
         const head = this.body.get(0);
         for (this.body.constSlice()) |part, i| {
             if (i == 0) continue;

--- a/site/docs/tutorials/snake/drawing-the-snake.md
+++ b/site/docs/tutorials/snake/drawing-the-snake.md
@@ -459,7 +459,7 @@ const w4 = @import("wasm4.zig");
 pub const Snake = struct {
     // ...
 
-    pub fn draw(this: @This()) void {
+    pub fn draw(this: *@This()) void {
         for(this.body.constSlice()) |part| {
             w4.rect(part.x * 8, part.y * 8, 8, 8);
         }
@@ -1071,7 +1071,7 @@ Since the body is drawn, head is not much of a problem. Simply use the `rect` fu
 The draw function should now look like this:
 
 ```zig {6}
-pub fn draw(this: @This()) void {
+pub fn draw(this: *@This()) void {
     for(this.body.constSlice()) |part| {
         w4.rect(part.x * 8, part.y * 8, 8, 8);
     }
@@ -1103,7 +1103,7 @@ The snippet above reads like this: "Color 1 uses Color 4 of the color palette, C
 If you change the source to
 
 ```zig {6}
-pub fn draw(this: @This()) void {
+pub fn draw(this: *@This()) void {
     for(this.body.constSlice()) |part| {
         w4.rect(part.x * 8, part.y * 8, 8, 8);
     }
@@ -1120,7 +1120,7 @@ Result:
 You'll see a change. The snake changed color. Not only the head, but the complete snake! Once you've set a color, it stays that way. So if you want to change only the head, you have to change Color 1 again. Right before you draw the body.
 
 ```zig {2}
-pub fn draw(this: @This()) void {
+pub fn draw(this: *@This()) void {
     w4.DRAW_COLORS.* = 0x0043;
     for(this.body.constSlice()) |part| {
         w4.rect(part.x * 8, part.y * 8, 8, 8);


### PR DESCRIPTION
Without the asterisks (`*`) I encountered some memory issues when using Zig's `std.BoundedArray`. Since I never used the language, it took me a while to figure out the problem, so I'm updating it for the future users.