### PR TITLE
proposed fix for issue #664

### DIFF
--- a/runtimes/web/src/ui/app.ts
+++ b/runtimes/web/src/ui/app.ts
@@ -131,10 +131,6 @@ export class App extends LitElement {
             this.netplay.join(hostPeerId);
         } else {
             await runtime.load(await loadCartWasm());
-
-            if (DEV_NETPLAY) {
-                this.copyNetplayLink();
-            }
         }
 
         let devtoolsManager = {
@@ -151,6 +147,10 @@ export class App extends LitElement {
 
         if (!this.netplay) {
             runtime.start();
+        }
+
+        if (DEV_NETPLAY) {
+            this.copyNetplayLink();
         }
 
         if (import.meta.env.DEV) {


### PR DESCRIPTION
When the DEV_NETPLAY flag is set to true, copyNetplayLink() is called in runtimes/web/app.ts. This sets this.netplay = true and copies the neplay url to the clipboard. However, this call to copyNetplayLink() is currently happening before the call to runtime.start(), which is only called if this.netplay == false. Since copyNetplayLink() sets this.netplay = true, this prevents runtime.start() from being called. It makes sense to avoid calls to runtim.start() by non-host players who join the game. However, it needs to be called by the host in order to perform any initial setup the game may require. Moving the check for the DEV_NETPLAY flag and the call to copyNetplayLink() after the call to runtime.start() fixes this issue.