### PR TITLE
Always call runtime.reset() in App.resetCart()

### DIFF
--- a/runtimes/web/src/ui/app.ts
+++ b/runtimes/web/src/ui/app.ts
@@ -646,9 +646,9 @@ export class App extends LitElement {
             // Take a snapshot
             state = new State();
             state.read(this.runtime);
-        } else {
-            this.runtime.reset(true);
         }
+        this.runtime.reset(true);
+
 
         this.runtime.pauseState |= constants.PAUSE_REBOOTING;
         await this.runtime.load(wasmBuffer);


### PR DESCRIPTION
I think this is technically the right thing to do, just in case the wasm start function or WASI _start/_initialize functions read from memory and then set some global variables (I don't know why they would, but they could.)
Probably wouldn't be necessary if we [fixed the global variable problem](https://github.com/aduros/wasm4/issues/649), and saved them in the `State`? Although thinking about it, there's other global state like wasm tables that we should worry about.

(Aside: I think we should try to tidy up the abstraction between runtime.reset(), runtime.load() and App.resetCart() a little, they seem a bit inter-dependant.)

Sorry for the train-of-thought pull request, I just find it helpful to have things written down 😊