### PR TITLE
zig: Replace `addSharedLibrary` with `addExecutable`

### DIFF
--- a/cli/assets/templates/zig/build.zig
+++ b/cli/assets/templates/zig/build.zig
@@ -1,22 +1,22 @@
 const std = @import("std");
 
 pub fn build(b: *std.Build) !void {
-    const optimize = b.standardOptimizeOption(.{});
-
-    const lib = b.addSharedLibrary(.{
+    const exe = b.addExecutable(.{
         .name = "cart",
         .root_source_file = .{ .path = "src/main.zig" },
-        .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
-        .optimize = optimize,
+        .target = .{
+            .cpu_arch = .wasm32,
+            .os_tag = .freestanding,
+        },
+        .optimize = b.standardOptimizeOption(.{}),
     });
 
-    lib.import_memory = true;
-    lib.initial_memory = 65536;
-    lib.max_memory = 65536;
-    lib.stack_size = 14752;
+    exe.entry = .disabled;
+    exe.export_symbol_names = &[_][]const u8{ "start", "update" };
+    exe.import_memory = true;
+    exe.initial_memory = 65536;
+    exe.max_memory = 65536;
+    exe.stack_size = 14752;
 
-    // Export WASM-4 symbols
-    lib.export_symbol_names = &[_][]const u8{ "start", "update" };
-
-    b.installArtifact(lib);
+    b.installArtifact(exe);
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Related to the breaking changes in https://github.com/ziglang/zig/pull/17815

This requires `0.12.0-dev.1482+e74ced21b` or later (currently the latest `master` release on https://ziglang.org/download/)