### PR TITLE
2 simple fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,8 @@ jobs:
                       wasm4: bin/wasm4
                       libretro: lib/wasm4_libretro.dylib
 
-                    - os: ubuntu-latest
+                    # glibc 2.31
+                    - os: ubuntu-20.04
                       artifact: "linux"
                       wasm4: bin/wasm4
                       libretro: lib/wasm4_libretro.so
@@ -33,9 +34,10 @@ jobs:
               with:
                   submodules: true
 
-            - if: matrix.config.os == 'ubuntu-latest'
+            - if: matrix.config.os == 'ubuntu-20.04'
               name: Install local dependencies
               run: |
+                  ldd --version
                   sudo apt update
                   sudo apt install libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev libxkbcommon-dev libasound2-dev libpulse-dev
 

--- a/cli/lib/new.js
+++ b/cli/lib/new.js
@@ -78,7 +78,7 @@ const HELP = {
     zig: {
       name: 'Zig',
       build: 'zig build -Doptimize=ReleaseSmall',
-      cart: 'zig-out/lib/cart.wasm',
+      cart: 'zig-out/bin/cart.wasm',
     }
 };
 

--- a/cli/lib/watch.js
+++ b/cli/lib/watch.js
@@ -21,7 +21,7 @@ function start (opts) {
     } else if (fs.existsSync("build.zig")) {
         buildCommand = "zig";
         buildParams = ["build"];
-        buildOutput = "zig-out/lib/cart.wasm";
+        buildOutput = "zig-out/bin/cart.wasm";
 
     } else if (fs.existsSync("cart.nimble")) {
         buildCommand = "nimble";

--- a/site/docs/getting-started/setup.md
+++ b/site/docs/getting-started/setup.md
@@ -368,7 +368,7 @@ zig build -Doptimize=ReleaseSmall
 Run it in WASM-4 with:
 
 ```shell
-w4 run zig-out/lib/cart.wasm
+w4 run zig-out/bin/cart.wasm
 ```
 
 </Page>

--- a/site/docs/tutorials/snake/publish-your-game.md
+++ b/site/docs/tutorials/snake/publish-your-game.md
@@ -111,7 +111,7 @@ This is a rather heavy, blunt hammer for functions that kind of look like nails 
 zig build -Doptimize=ReleaseSmall
 ```
 
-Your game will be here: `zig-out/lib/cart.wasm`
+Your game will be here: `zig-out/bin/cart.wasm`
 
 </Page>
 


### PR DESCRIPTION
b19c86b15bc09c1bbdfbda3a003b92b61297d005: Fixes `w4` looking for `cart.wasm` in the wrong location since #669.
5063e90d7fc592fae5a1168cbfd19ca7473a697d: Makes the native binary compatible with linux installations older than ~2 years.