### PR TITLE
Add support for Roc in png2src

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -4,7 +4,7 @@ const { program, Option } = require("commander");
 const pkg = require('./package.json');
 const { supportedIconExtensions } = require('./lib/utils/icon');
 
-const LANGS = ["assemblyscript", "c", "c3", "cpp", "d", "go", "nelua", "nim", "odin", "penne", "porth", "roland", "rust", "wat", "zig"];
+const LANGS = ["assemblyscript", "c", "c3", "cpp", "d", "go", "nelua", "nim", "odin", "penne", "porth", "roc", "roland", "rust", "wat", "zig"];
 const langOption = new Option("--lang <lang>", "Use the given language")
     .env("W4_LANG")
     .choices(LANGS);
@@ -36,6 +36,8 @@ function requireLang (opts) {
         return "penne";
     } else if (opts.porth) {
         return "porth";
+    } else if (opts.roc) {
+        return "roc";
     } else if (opts.roland) {
         return "roland";
     } else if (opts.rust) {
@@ -151,6 +153,7 @@ program.command("png2src <images...>")
     .option("--odin", "Generate Odin source (Shorthand for --lang odin)")
     .option("--penne", "Generate Penne source (Shorthand for --lang penne)")
     .option("--porth", "Generate Porth source (Shorthand for --lang porth)")
+    .option("--roc", "Generate Roc source (Shorthand for --lang roc)")
     .option("--roland", "Generate Roland source (Shorthand for --lang roland)")
     .option("--rs, --rust", "Generate Rust source (Shorthand for --lang rust)")
     .option("--wat", "Generate WebAssembly Text source (Shorthand for --lang wat)")

--- a/cli/lib/png2src.js
+++ b/cli/lib/png2src.js
@@ -104,6 +104,18 @@ const {{name}}-width  {{width}} end
 
 {{/sprites}}`,
 
+    roc:
+        `{{#sprites}}
+# {{name}} sprite
+{{name}}Sprite = Sprite.new {
+    data: [ {{bytes}} ],
+    bpp: BPP{{bpp}},
+    width: {{width}},
+    height: {{height}},
+}
+
+{{/sprites}}`,
+
     roland:
         `{{#sprites}}
 // {{name}}
@@ -308,6 +320,7 @@ The first occurrence of another color is at (${x}, ${y}) and has the value of (R
         "flags": flags,
         "flagsHumanReadable": flagsHumanReadable,
         "bytes": data,
+        "bpp": bpp,
         "firstByte": dataBytes[0],
         "restBytes": dataBytes.slice(1).join(','),
         "wasmBytes": wasmBytes.join(''),

--- a/site/docs/reference/cli.md
+++ b/site/docs/reference/cli.md
@@ -243,6 +243,7 @@ w4 png2src --lang rust top.png down.png left.png right.png
 | --nim            |               | Generates Nim source                      |
 | --odin           |               | Generates Odin source                     |
 | --porth          |               | Generates Porth source                    |
+| --roc            |               | Generates Roc source                      |
 | --roland         |               | Generates Roland source                   |
 | --rs             |               | Generates Rust source                     |
 | --rust           |               | Same as `--rs`                            |


### PR DESCRIPTION
A friend and I have been working on support w4 in Roc. That project lives here: https://github.com/lukewilliamboswell/roc-wasm4/

This adds png2src support for Roc. Note, Roc does not store all flags with a sprite. Instead, roc just stores bits per pixel and leaves the rest of the flags for when calling `blit` or `blitSub`.