### PR TITLE
zig: Fix template build

### DIFF
--- a/cli/assets/templates/zig/build.zig
+++ b/cli/assets/templates/zig/build.zig
@@ -4,15 +4,15 @@ pub fn build(b: *std.Build) !void {
     const exe = b.addExecutable(.{
         .name = "cart",
         .root_source_file = .{ .path = "src/main.zig" },
-        .target = .{
+        .target = b.resolveTargetQuery(.{
             .cpu_arch = .wasm32,
             .os_tag = .freestanding,
-        },
+        }),
         .optimize = b.standardOptimizeOption(.{}),
     });
 
     exe.entry = .disabled;
-    exe.export_symbol_names = &[_][]const u8{ "start", "update" };
+    exe.root_module.export_symbol_names = &[_][]const u8{ "start", "update" };
     exe.import_memory = true;
     exe.initial_memory = 65536;
     exe.max_memory = 65536;


### PR DESCRIPTION
I'm not sure when or why these changes occurred in Zig, but with this fix I can compile the template on the latest version of Zig.