### PR TITLE
Fix imports in the WAT template

### DIFF
--- a/cli/assets/templates/wat/main.wat
+++ b/cli/assets/templates/wat/main.wat
@@ -46,16 +46,13 @@
 ;; │                                                                           │
 ;; └───────────────────────────────────────────────────────────────────────────┘
 (; Reads up to `size` bytes from persistent storage into the pointer `dest`. ;)
-(import "env" "diskr" (func $diskr (param i32 i32)))
+(import "env" "diskr" (func $diskr (param i32 i32) (result i32)))
 
 (; Writes up to `size` bytes from the pointer `src` into persistent storage. ;)
-(import "env" "diskw" (func $diskw (param i32 i32)))
+(import "env" "diskw" (func $diskw (param i32 i32) (result i32)))
 
 (; Prints a message to the debug console. ;)
 (import "env" "trace" (func $trace (param i32)))
-
-(; Prints a message to the debug console. ;)
-(import "env" "tracef" (func $tracef (param i32 i32)))
 
 
 ;; ┌───────────────────────────────────────────────────────────────────────────┐


### PR DESCRIPTION
1. `diskr` and `diskw` return an i32 (number of bytes written).
2. `tracef` is not provided by the host environment, it's just a helper in the C SDK.

You didn't have an error running the example because binaryen strips out all the unused imports. It would fail if you use any of these function or if you don't have binaryen installed.