### PR TITLE
zig: allow 'zig build run'

### DIFF
--- a/cli/assets/templates/zig/build.zig
+++ b/cli/assets/templates/zig/build.zig
@@ -19,4 +19,10 @@ pub fn build(b: *std.Build) !void {
     exe.stack_size = 14752;
 
     b.installArtifact(exe);
+
+    const run_exe = b.addSystemCommand(&.{ "w4", "run-native" });
+    run_exe.addArtifactArg(exe);
+
+    const step_run = b.step("run", "compile and run the cart");
+    step_run.dependOn(&run_exe.step);
 }


### PR DESCRIPTION
Run the cart with `zig build run`.