### PR TITLE
✨ Make APU tick aware ✨ 

### DIFF
--- a/runtimes/native/src/apu.h
+++ b/runtimes/native/src/apu.h
@@ -5,6 +5,8 @@
 
 void w4_apuInit ();
 
+void w4_apuTick ();
+
 void w4_apuTone (int frequency, int duration, int volume, int flags);
 
 void w4_apuWriteSamples (int16_t* output, unsigned long frames);

--- a/runtimes/native/src/runtime.c
+++ b/runtimes/native/src/runtime.c
@@ -184,6 +184,7 @@ void w4_runtimeUpdate () {
         w4_framebufferClear();
     }
     w4_wasmCallUpdate();
+    w4_apuTick();
     uint32_t palette[4] = {
         w4_read32LE(&memory->palette[0]),
         w4_read32LE(&memory->palette[1]),

--- a/runtimes/web/src/apu.ts
+++ b/runtimes/web/src/apu.ts
@@ -55,12 +55,18 @@ export class APU {
         }
     }
 
-    tone (frequency: number, duration: number, volume: number, flags: number) {
-        const processorPort = this.processorPort;
-        if (processorPort != null) {
-            // Send params out to the worker
-            processorPort.postMessage([frequency, duration, volume, flags]);
+    tick() {
+        if (this.processorPort != null) {
+            this.processorPort.postMessage('tick');
+        } else {
+            this.processor.tick();
+        }
+    }
 
+    tone (frequency: number, duration: number, volume: number, flags: number) {
+        if (this.processorPort != null) {
+            // Send params out to the worker
+            this.processorPort.postMessage([frequency, duration, volume, flags]);
         } else {
             // For the ScriptProcessorNode fallback, just call tone() directly
             this.processor.tone(frequency, duration, volume, flags);

--- a/runtimes/web/src/runtime.ts
+++ b/runtimes/web/src/runtime.ts
@@ -334,6 +334,7 @@ export class Runtime {
         let update_function = this.wasm!.exports["update"];
         if (typeof update_function === "function") {
             this.bluescreenOnError(update_function);
+            this.apu.tick();
         }
     }
 


### PR DESCRIPTION
## What

It has always been an issue that if you try to continously play `tone` each frame, you will get gaps due to frame timing issues. This has made doing live-playback or creating very fancy sounds difficult.
The previous workaround has been to extend each `tone` so that the next one will override it, but this has several drawbacks when working with pitch-bends.

What is done here is make the APU aware of WASM-4 ticks. This enables us to keep playing the active `tone` past its expiration as long as the next tick hasn't rolled in yet, thus avoiding gaps in playback.

## Demo

Here is a video demonstration of the fix: [**demo**](https://github.com/aduros/wasm4/assets/3710677/34f58e2f-1d12-4a8a-ade9-6af052062b34)

This also shows that it only affects continously calling `tone` with sustain and doesn't affect intentional skipping or envelopes (which is correct.)
Has been tested on both web and native, on Windows and Linux. 

## Example

Here's the cart I used to test this and the Zig code for it: [**cart.wasm**](https://github.com/aduros/wasm4/files/15002323/cart.zip)

```zig
const w4 = @import("wasm4.zig");

export fn start() void {}

var ticks: usize = 0;
export fn update() void {
    w4.DRAW_COLORS.* = 0x14;
    w4.text("\x80:continous", 5, 5);
    w4.text("\x81:skip 1", 5, 15);
    w4.text("\x84:skip 2", 5, 25);
    w4.text("\x86:continous release", 5, 35);
    w4.text("\x85:skip 1 release", 5, 45);

    w4.DRAW_COLORS.* = 0x13;
    if (w4.GAMEPAD1.* & w4.BUTTON_1 > 0) {
        w4.text("continous", 5, 80);
        w4.tone(500, 1, 50, 0);
    } else if (w4.GAMEPAD1.* & w4.BUTTON_2 > 0) {
        if ((ticks % 2) == 0) {
            w4.text("skip 1", 5, 80);
            w4.tone(500, 1, 50, 0);
        }
    } else if (w4.GAMEPAD1.* & w4.BUTTON_LEFT > 0) {
        if ((ticks % 3) == 0) {
            w4.text("skip 2", 5, 80);
            w4.tone(500, 1, 50, 0);
        }
    } else if (w4.GAMEPAD1.* & w4.BUTTON_UP > 0) {
        w4.text("continous release", 5, 80);
        w4.tone(500, 1 << 8, 50, 0);
    } else if (w4.GAMEPAD1.* & w4.BUTTON_RIGHT > 0) {
        if ((ticks % 2) == 0) {
            w4.text("skip 1 release", 5, 80);
            w4.tone(500, 1 << 8, 50, 0);
        }
    }
    ticks += 1;
}
```

I also tested some code doing continous frequency sweeps and the difference is night and day, even when doing workarounds with the old version.
