### PR TITLE
APU Note Mode (alternative version of #334)

### DIFF
--- a/cli/assets/templates/assemblyscript/src/wasm4.ts
+++ b/cli/assets/templates/assemblyscript/src/wasm4.ts
@@ -121,6 +121,7 @@ export const TONE_MODE3: u32 = 8;
 export const TONE_MODE4: u32 = 12;
 export const TONE_PAN_LEFT: u32 = 16;
 export const TONE_PAN_RIGHT: u32 = 32;
+export const TONE_NOTE_MODE: u32 = 64;
 
 // ┌───────────────────────────────────────────────────────────────────────────┐
 // │                                                                           │

--- a/cli/assets/templates/c/src/wasm4.h
+++ b/cli/assets/templates/c/src/wasm4.h
@@ -117,6 +117,7 @@ void tone (uint32_t frequency, uint32_t duration, uint32_t volume, uint32_t flag
 #define TONE_MODE4 12
 #define TONE_PAN_LEFT 16
 #define TONE_PAN_RIGHT 32
+#define TONE_NOTE_MODE 64
 
 // ┌───────────────────────────────────────────────────────────────────────────┐
 // │                                                                           │

--- a/cli/assets/templates/c3/cart/src/wasm4.c3
+++ b/cli/assets/templates/c3/cart/src/wasm4.c3
@@ -97,6 +97,7 @@ const TONE_MODE3 = 8;
 const TONE_MODE4 = 12;
 const TONE_PAN_LEFT = 16;
 const TONE_PAN_RIGHT = 32;
+const TONE_NOTE_MODE = 64;
 
 // ┌───────────────────────────────────────────────────────────────────────────┐
 // │                                                                           │

--- a/cli/assets/templates/d/source/wasm4.d
+++ b/cli/assets/templates/d/source/wasm4.d
@@ -101,6 +101,7 @@ enum toneMode3 = 8;
 enum toneMode4 = 12;
 enum tonePanLeft = 16;
 enum tonePanRight = 32;
+enum toneNoteMode = 64;
 
 // ┌───────────────────────────────────────────────────────────────────────────┐
 // │                                                                           │

--- a/cli/assets/templates/go/w4/wasm4.go
+++ b/cli/assets/templates/go/w4/wasm4.go
@@ -111,6 +111,7 @@ const TONE_MODE3 = 8
 const TONE_MODE4 = 12
 const TONE_PAN_LEFT = 16
 const TONE_PAN_RIGHT = 32
+const TONE_NOTE_MODE = 64
 
 // ┌───────────────────────────────────────────────────────────────────────────┐
 // │                                                                           │

--- a/cli/assets/templates/nelua/src/wasm4.nelua
+++ b/cli/assets/templates/nelua/src/wasm4.nelua
@@ -122,6 +122,7 @@ global TONE_MODE3 <comptime> = 8
 global TONE_MODE4 <comptime> = 12
 global TONE_PAN_LEFT <comptime> = 16
 global TONE_PAN_RIGHT <comptime> = 32
+global TONE_NOTE_MODE <comptime> = 64
 
 -- ┌───────────────────────────────────────────────────────────────────────────┐
 -- │                                                                           │

--- a/cli/assets/templates/nim/src/cart/wasm4.nim
+++ b/cli/assets/templates/nim/src/cart/wasm4.nim
@@ -48,6 +48,7 @@ const
   TONE_MODE4* = 12
   TONE_PAN_LEFT* = 16
   TONE_PAN_RIGHT* = 32
+  TONE_NOTE_MODE* = 64
 
 {.push importc, codegenDecl: "__attribute__((import_name(\"$2\"))) $1 $2$3".}
 proc blit*(data: ptr uint8; x: int32; y: int32; width: uint32; height: uint32;

--- a/cli/assets/templates/odin/src/w4/wasm4_wasm32.odin
+++ b/cli/assets/templates/odin/src/w4/wasm4_wasm32.odin
@@ -118,6 +118,10 @@ Tone_Pan :: enum u32 {
 	Left   = 16,
 	Right  = 32,
 }
+Tone_Mode :: enum u32 {
+	Frequency = 0,
+	Note      = 64,
+}
 
 Tone_Duration :: struct {
 	attack:  u8, // in frames
@@ -135,13 +139,13 @@ foreign wasm4 {
 }
 
 // Plays a sound tone.
-tone :: proc "c" (frequency: u32, duration: u32, volume_percent: u32, channel: Tone_Channel, duty_cycle := Tone_Duty_Cycle.Eigth, pan := Tone_Pan.Center) {
-	flags := u32(channel) | u32(duty_cycle) | u32(pan)
+tone :: proc "c" (frequency: u32, duration: u32, volume_percent: u32, channel: Tone_Channel, duty_cycle := Tone_Duty_Cycle.Eigth, pan := Tone_Pan.Center, tone_mode := Tone_Mode.Frequency) {
+	flags := u32(channel) | u32(duty_cycle) | u32(pan) | u32(tone_mode)
 	internal_tone(frequency, duration, volume_percent, flags)
 }
 
-tone_complex :: proc "c" (start_frequency, end_frequency: u16, duration: Tone_Duration, volume_percent: u32, channel: Tone_Channel, duty_cycle := Tone_Duty_Cycle.Eigth, pan := Tone_Pan.Center) {
-	flags := u32(channel) | u32(duty_cycle) | u32(pan)
+tone_complex :: proc "c" (start_frequency, end_frequency: u16, duration: Tone_Duration, volume_percent: u32, channel: Tone_Channel, duty_cycle := Tone_Duty_Cycle.Eigth, pan := Tone_Pan.Center, tone_mode := Tone_Mode.Frequency) {
+	flags := u32(channel) | u32(duty_cycle) | u32(pan) | u32(tone_mode)
 	frequency := u32(start_frequency) | u32(end_frequency)<<16
 	duration_in_frames := u32(duration.attack)<<24 | u32(duration.delay)<<16 | u32(duration.release)<<8 | u32(duration.sustain)
 	

--- a/cli/assets/templates/penne/src/wasm4.pn
+++ b/cli/assets/templates/penne/src/wasm4.pn
@@ -103,6 +103,7 @@ pub const TONE_MODE3: u32 = 8;
 pub const TONE_MODE4: u32 = 12;
 pub const TONE_PAN_LEFT: u32 = 16;
 pub const TONE_PAN_RIGHT: u32 = 32;
+pub const TONE_NOTE_MODE: u32 = 64;
 
 // ┌───────────────────────────────────────────────────────────────────────────┐
 // │                                                                           │

--- a/cli/assets/templates/rust/src/wasm4.rs
+++ b/cli/assets/templates/rust/src/wasm4.rs
@@ -193,6 +193,7 @@ pub const TONE_MODE3: u32 = 8;
 pub const TONE_MODE4: u32 = 12;
 pub const TONE_PAN_LEFT: u32 = 16;
 pub const TONE_PAN_RIGHT: u32 = 32;
+pub const TONE_NOTE_MODE: u32 = 64;
 
 // ┌───────────────────────────────────────────────────────────────────────────┐
 // │                                                                           │

--- a/cli/assets/templates/wat/main.wat
+++ b/cli/assets/templates/wat/main.wat
@@ -109,6 +109,7 @@
 (global $TONE_MODE4 i32 (i32.const 12))
 (global $TONE_PAN_LEFT i32 (i32.const 16))
 (global $TONE_PAN_RIGHT i32 (i32.const 32))
+(global $TONE_NOTE_MODE i32 (i32.const 64))
 
 
 ;; smiley

--- a/cli/assets/templates/zig/src/wasm4.zig
+++ b/cli/assets/templates/zig/src/wasm4.zig
@@ -100,6 +100,7 @@ pub const TONE_MODE3: u32 = 8;
 pub const TONE_MODE4: u32 = 12;
 pub const TONE_PAN_LEFT: u32 = 16;
 pub const TONE_PAN_RIGHT: u32 = 32;
+pub const TONE_NOTE_MODE: u32 = 64;
 
 // ┌───────────────────────────────────────────────────────────────────────────┐
 // │                                                                           │

--- a/site/docs/guides/audio.md
+++ b/site/docs/guides/audio.md
@@ -409,6 +409,81 @@ w4.tone(262, 60, 100, w4.TONE_PULSE1 | w4.TONE_PAN_LEFT);
 
 </MultiLanguageCode>
 
+## Note Mode
+
+By enabling Note Mode with the `TONE_NOTE_MODE` flag, `tone` will use MIDI note numbers rather than frequencies.
+This results in more accurate pitches when playing musical notes.
+
+You can read more about how this works in the [`tone(...)` documentation](../reference/functions#tone-frequency-duration-volume-flags).
+
+Here's the same example as before, now playing middle-C using the MIDI note number 60:
+
+<MultiLanguageCode>
+
+```typescript
+w4.tone(60, 60, 100, w4.TONE_PULSE1 | w4.TONE_NOTE_MODE);
+```
+
+```c
+tone(60, 60, 100, TONE_PULSE1 | TONE_NOTE_MODE);
+```
+
+```c3
+w4::tone(60, 60, 100, w4::TONE_PULSE1 | w4::TONE_NOTE_MODE);
+```
+
+```d
+w4.tone(60, 60, 100, w4.tonePulse1 | w4.toneNoteMode);
+```
+
+```go
+w4.Tone(60, 60, 100, w4.TONE_PULSE1 | w4.TONE_NOTE_MODE)
+```
+
+```lua
+tone(60, 60, 100, TONE_PULSE1 | TONE_NOTE_MODE)
+```
+
+```nim
+tone(60, 60, 100, TONE_PULSE1 or TONE_NOTE_MODE)
+```
+
+```odin
+w4.tone(60, 60, 100, .Pulse1, .Half, .Left, .Note)
+```
+
+```penne
+tone(60, 60, 100, TONE_PULSE1 | TONE_NOTE_MODE);
+```
+
+```porth
+$TONE_NOTE_MODE $TONE_PULSE1 or 100 60 60 tone
+```
+
+```roland
+tone(60, 60, 100, TONE_PULSE1 | TONE_NOTE_MODE);
+```
+
+```rust
+tone(60, 60, 100, TONE_PULSE1 | TONE_NOTE_MODE);
+```
+
+```wasm
+(call $tone
+  (i32.const 60)
+  (i32.const 60)
+  (i32.const 100)
+  (i32.or
+    (global.get $TONE_PULSE1)
+    (global.get $TONE_NOTE_MODE)))
+```
+
+```zig
+w4.tone(60, 60, 100, w4.TONE_PULSE1 | w4.TONE_NOTE_MODE);
+```
+
+</MultiLanguageCode>
+
 ## Calculating Flags
 
 Setting ADSR flags require the use of various bitwise and bitshift operations. This can be a little confusing to understand.

--- a/site/docs/reference/functions.md
+++ b/site/docs/reference/functions.md
@@ -113,6 +113,7 @@ Plays a sound tone.
 | 0 - 1     | Channel (0-3): 0 = Pulse1, 1 = Pulse2, 2 = Triangle, 3 = Noise                                |
 | 2 - 3     | Mode (0-3): For pulse channels, the pulse wave duty cycle. 0 = 1/8, 1 = 1/4, 2 = 1/2, 3 = 3/4 |
 | 4 - 5     | Pan (0-2): 0 = Center, 1 = Left, 2 = Right                                                    |
+| 6         | Use *Note Mode* for frequencies: See below.                                                   |
 
 The high bits of `frequency` can optionally describe a pitch slide effect:
 
@@ -122,6 +123,13 @@ The high bits of `frequency` can optionally describe a pitch slide effect:
 | 16 - 31        | End frequency (0-65535)   |
 
 If the end frequency is non-zero, then the frequency is ramped linearly over the total duration of the tone.
+
+If *Note Mode* is enabled, both the Start and End frequency values are instead interpreted as notes with pitch bend rather than frequencies:
+
+| Frequency bits | Description                                                                                          |
+| ---            | ---                                                                                                  |
+| 0 - 7          | Note (0-255): Note number according to the MIDI specification, e.g. 60 = C4, 69 = A4 (440 Hz)        |
+| 8 - 15         | Note bend (0-255): Bend note upwards. 0 = Nothing, 255 = One 256th away from the next note above     |
 
 The high bits of `duration` can optionally describe an ADSR volume envelope:
 


### PR DESCRIPTION
This is another go at #333, but with a slightly different approach from #334.

Big thanks to @marler8997 for the detailed proposal and the other PR!

Has been tested working on both web and native.

## Reasoning

Since frequencies sent to `tone` are integers, we lose quite a bit of precision when it comes to playing lower notes. This PR implements a variant of #333 to make `tone` capable of playing MIDI notes. We have 16 bits per frequency, which is split up into 8 bits for the note, and 8 bits for optional pitch bend, as to not be limited to pure notes.

It turns out the implementation for this is very simple (JS implementation required less than 15 lines!), and since the flag is new and optional it doesn't affect any prior carts. In my opinion this feature is overdue.

## Usage

Instead of calling `tone` with frequencies, you supply it with notes. The list of MIDI notes is easily googlable and easier to use than frequencies: https://inspiredacoustics.com/en/MIDI_note_numbers_and_center_frequencies

```c
// Play A4 (440Hz)
tone(69, 0, 0, TONE_NOTE_MODE)
// Play A4 bent halfway up to the next note (A#4)
tone(69 | 128 << 8, 0, 0, TONE_NOTE_MODE)
```

One could compare the pitch bends to cents between semitones in music, where 128 bend would be the equivalent to 50 cents.

## Compared to #334 in short:
- `TONE_NOTE_MODE` flag for `tone` rather than a system flag.
- Puts the main note in the lower bits rather than the upper bits (i.e. `tone(note | bend << 8, ...)` rather than `tone(bend | note << 8, ...)`.)

