### PR TITLE
apu: fix continous tone for triangle

### DIFF
--- a/runtimes/web/src/runtime.ts
+++ b/runtimes/web/src/runtime.ts
@@ -334,8 +334,8 @@ export class Runtime {
         let update_function = this.wasm!.exports["update"];
         if (typeof update_function === "function") {
             this.bluescreenOnError(update_function);
-            this.apu.tick();
         }
+        this.apu.tick();
     }
 
     blueScreen (text: string) {


### PR DESCRIPTION
Related to #705 

I found that the triangle wave behaved incorrectly, and this was due to its specific `releaseTime` being added.
I had tested the triangle wave locally before submitting the last PR, but did so at a different sample rate so maybe that affected something, I don't know.

Here's a piece of code to test this bug with:

```zig
const w4 = @import("wasm4.zig");

export fn start() void {}

var ticks: usize = 0;
export fn update() void {
    w4.DRAW_COLORS.* = 0x14;
    w4.text("\x80:short attack", 5, 5);
    w4.text("\x81:short decay", 5, 15);
    w4.text("\x84:short sustain", 5, 25);
    w4.text("\x86:long release", 5, 35);
    w4.text("\x87:short sus tri", 5, 45);
    w4.text("\x85:short decay tri", 5, 55);

    w4.DRAW_COLORS.* = 0x13;
    if (w4.GAMEPAD1.* & w4.BUTTON_1 > 0) {
        w4.text("A", 5, 80);
        w4.tone(60, 1 << 24, 50 | (50 << 8), 0x40);
    } else if (w4.GAMEPAD1.* & w4.BUTTON_2 > 0) {
        w4.text("D", 5, 80);
        w4.tone(60, 1 << 16, 50 | (50 << 8), 0x40);
    } else if (w4.GAMEPAD1.* & w4.BUTTON_LEFT > 0) {
        w4.text("S", 5, 80);
        w4.tone(60, 1, 50 | (50 << 8), 0x40);
    } else if (w4.GAMEPAD1.* & w4.BUTTON_UP > 0) {
        w4.text("R", 5, 80);
        w4.tone(60, 255 << 8, 50 | (50 << 8), 0x40);
    } else if (w4.GAMEPAD1.* & w4.BUTTON_DOWN > 0) {
        w4.text("D tri", 5, 80);
        w4.tone(60, 1 << 16, 50 | (50 << 8), 0x40 | 0x2);
    } else if (w4.GAMEPAD1.* & w4.BUTTON_RIGHT > 0) {
        w4.text("S tri", 5, 80);
        w4.tone(60, 1, 50 | (50 << 8), 0x40 | 0x2);
    }
    ticks += 1;
}
```

As a bonus, also contains a fix majaha mentioned if someone would call `tone` in `start` but not export an `update` from their WASM.