### PR TITLE
png2src: add ability to handle any width

### DIFF
--- a/cli/lib/png2src.js
+++ b/cli/lib/png2src.js
@@ -240,12 +240,7 @@ The first occurrence of another color is at (${x}, ${y}) and has the value of (R
         odinFlags = "{ .USE_2BPP }"
     }
 
-    const factor = 8 / bpp;
-    if (png.width % factor != 0) {
-        throw new Error(`${bpp}BPP sprites must have a width divisible by ${factor}`);
-    }
-
-    const bytes = new Uint8Array(png.width * png.height * bpp / 8);
+    const bytes = new Uint8Array((png.width * png.height * bpp + 7 ) / 8);
 
     // Read a color (palette index) from the source png
     function readColor(x, y) {
@@ -260,25 +255,15 @@ The first occurrence of another color is at (${x}, ${y}) and has the value of (R
 
     // Write a color (palette index) to the output buffer
     function writeColor(color, x, y) {
-        let idx, shift, mask;
-        switch (bpp) {
-            case 1:
-                idx = (y * png.width + x) >> 3;
-                shift = 7 - (x & 0x07);
-                mask = 0x1 << shift;
-                break;
-
-            case 2:
-                idx = (y * png.width + x) >> 2;
-                shift = 6 - ((x & 0x3) << 1);
-                mask = 0x3 << shift;
-                break;
-
-            default:
-                throw new Error("assert");
+        if(bpp < 0 || bpp > 2){
+            throw new Error("unexpexted bpp");
         }
 
-        bytes[idx] = (color << shift) | (bytes[idx] & (~mask));
+        const color_idx = (y * png.width + x);
+        const idx = Math.floor(color_idx / ( 8 / bpp ));
+        const shift = ((8 / bpp - 1)-color_idx % ( 8 / bpp )) * bpp;
+
+        bytes[idx] = (color << shift) | (bytes[idx]);
     }
 
     for (let y = 0; y < png.height; ++y) {

--- a/cli/lib/png2src.js
+++ b/cli/lib/png2src.js
@@ -256,7 +256,7 @@ The first occurrence of another color is at (${x}, ${y}) and has the value of (R
     // Write a color (palette index) to the output buffer
     function writeColor(color, x, y) {
         if(bpp != 1 && bpp != 2){
-            throw new Error("unexpexted bpp");
+            throw new Error("Unexpected bpp");
         }
 
         const color_idx = (y * png.width + x);

--- a/cli/lib/png2src.js
+++ b/cli/lib/png2src.js
@@ -255,7 +255,7 @@ The first occurrence of another color is at (${x}, ${y}) and has the value of (R
 
     // Write a color (palette index) to the output buffer
     function writeColor(color, x, y) {
-        if(bpp < 0 || bpp > 2){
+        if(bpp != 1 && bpp != 2){
             throw new Error("unexpexted bpp");
         }
 


### PR DESCRIPTION
solves #497

tested on these images, for 1bpp and 2bpp:

7x7 pixels:
![smiley_1bpp_7x7](https://github.com/aduros/wasm4/assets/50550773/6b6a28d5-6127-446d-a305-eab1da491f63)
![smiley_2bpp_7x7](https://github.com/aduros/wasm4/assets/50550773/69298e4f-6f17-46ce-846b-beba35f51896)

8x8 pixels:
![smiley_1bpp_8x8](https://github.com/aduros/wasm4/assets/50550773/59b5af65-8c34-4272-a8d4-17476033da9e)
![smiley_2bpp_8x8](https://github.com/aduros/wasm4/assets/50550773/a057dae4-47dd-4280-934d-4f68f1c891e1)
