### PR TITLE
rect: fix bounds

### DIFF
--- a/runtimes/native/src/framebuffer.c
+++ b/runtimes/native/src/framebuffer.c
@@ -334,8 +334,8 @@ void w4_framebufferRect (int x, int y, int width, int height) {
     int startY = w4_max(0, y);
     int endXUnclamped = x + width;
     int endYUnclamped = y + height;
-    int endX = w4_min(endXUnclamped, WIDTH);
-    int endY = w4_min(endYUnclamped, HEIGHT);
+    int endX = w4_max(0, w4_min(endXUnclamped, WIDTH));
+    int endY = w4_max(0, w4_min(endYUnclamped, HEIGHT));
 
     uint8_t dc01 = drawColors[0];
     uint8_t dc0 = dc01 & 0xf;

--- a/runtimes/web/src/framebuffer.ts
+++ b/runtimes/web/src/framebuffer.ts
@@ -101,8 +101,8 @@ export class Framebuffer {
         const startY = Math.max(0, y);
         const endXUnclamped = x + width;
         const endYUnclamped = y + height;
-        const endX = Math.min(endXUnclamped, WIDTH);
-        const endY = Math.min(endYUnclamped, HEIGHT);
+        const endX = Math.max(0, Math.min(endXUnclamped, WIDTH));
+        const endY = Math.max(0, Math.min(endYUnclamped, HEIGHT));
 
         const drawColors = this.drawColors[0];
         const dc0 = drawColors & 0xf;


### PR DESCRIPTION
If x+width goes off-screen in the negative it would corrupt the framebuffer.