### PR TITLE
Fix Zig template for Zig 0.13.0

### DIFF
--- a/cli/assets/templates/zig/.gitignore
+++ b/cli/assets/templates/zig/.gitignore
@@ -1,2 +1,3 @@
+/.zig-cache
 /zig-cache
 /zig-out

--- a/cli/assets/templates/zig/build.zig
+++ b/cli/assets/templates/zig/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 pub fn build(b: *std.Build) !void {
     const exe = b.addExecutable(.{
         .name = "cart",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = b.resolveTargetQuery(.{
             .cpu_arch = .wasm32,
             .os_tag = .freestanding,


### PR DESCRIPTION
- `zig-cache` renamed to `.zig-cache`  
https://ziglang.org/download/0.13.0/release-notes.html#codezig-cachecode-renamed-to-codezig-cachecode
- introduce `b.path`; deprecate `LazyPath.relative` (removed in 0.13.0)
https://ziglang.org/download/0.12.0/release-notes.html#introduce-bpath-deprecate-LazyPathrelative  