### PR TITLE
compile with --threads:off Update cart.nimble

### DIFF
--- a/cli/assets/templates/nim/cart.nimble
+++ b/cli/assets/templates/nim/cart.nimble
@@ -21,6 +21,6 @@ task rel, "Build the cartridge with all optimizations":
 after rel:
   let exe = findExe("wasm-opt")
   if exe != "":
-    exec(&"wasm-opt -Oz --zero-filled-memory --strip-producers {outFile} -o {outFile}")
+    exec(&"wasm-opt --enable-bulk-memory -Oz --zero-filled-memory --strip-producers {outFile} -o {outFile}")
   else:
     echo "Tip: wasm-opt was not found. Install it from binaryen for smaller builds!"

--- a/cli/assets/templates/nim/cart.nimble
+++ b/cli/assets/templates/nim/cart.nimble
@@ -13,10 +13,10 @@ let outFile = "build" / "cart.wasm"
 requires "nim >= 1.4.0"
 
 task dbg, "Build the cartridge in debug mode":
-  exec &"nim c -d:nimNoQuit -o:{outFile} src/cart.nim"
+  exec &"nim c --threads:off -d:nimNoQuit -o:{outFile} src/cart.nim"
 
 task rel, "Build the cartridge with all optimizations":
-  exec &"nim c -d:nimNoQuit -d:danger -o:{outFile} src/cart.nim"
+  exec &"nim c --threads:off -d:nimNoQuit -d:danger -o:{outFile} src/cart.nim"
 
 after rel:
   let exe = findExe("wasm-opt")


### PR DESCRIPTION
When compiling the cart, an error occurs:
Threads not implemented for os:any. Please compile with --threads:off. stack trace: (most recent call last)

Added --threads:off flag, for successful compilation of the cart