### PR TITLE
fix: transparent oval outline

### DIFF
--- a/runtimes/native/src/framebuffer.c
+++ b/runtimes/native/src/framebuffer.c
@@ -426,10 +426,12 @@ void w4_framebufferOval (int x, int y, int width, int height) {
     b1 = 8 * b2;
 
     do {
-        drawPointUnclipped(strokeColor, east, north); /*   I. Quadrant     */
-        drawPointUnclipped(strokeColor, west, north); /*   II. Quadrant    */
-        drawPointUnclipped(strokeColor, west, south); /*   III. Quadrant   */
-        drawPointUnclipped(strokeColor, east, south); /*   IV. Quadrant    */
+        if (dc1 != 0) {
+            drawPointUnclipped(strokeColor, east, north); /*   I. Quadrant     */
+            drawPointUnclipped(strokeColor, west, north); /*   II. Quadrant    */
+            drawPointUnclipped(strokeColor, west, south); /*   III. Quadrant   */
+            drawPointUnclipped(strokeColor, east, south); /*   IV. Quadrant    */
+        }
 
         const int start = west + 1;
         const int len = east - start;
@@ -458,14 +460,16 @@ void w4_framebufferOval (int x, int y, int width, int height) {
         }
     } while (west <= east);
 
-    // Make sure north and south have moved the entire way so top/bottom aren't missing
-    while (north - south < height) {
-        drawPointUnclipped(strokeColor, west - 1, north); /*   II. Quadrant    */
-        drawPointUnclipped(strokeColor, east + 1, north); /*   I. Quadrant     */
-        north += 1;
-        drawPointUnclipped(strokeColor, west - 1, south); /*   III. Quadrant   */
-        drawPointUnclipped(strokeColor, east + 1, south); /*   IV. Quadrant    */
-        south -= 1;
+    if (dc1 != 0) {
+        // Make sure north and south have moved the entire way so top/bottom aren't missing
+        while (north - south < height) {
+            drawPointUnclipped(strokeColor, west - 1, north); /*   II. Quadrant    */
+            drawPointUnclipped(strokeColor, east + 1, north); /*   I. Quadrant     */
+            north += 1;
+            drawPointUnclipped(strokeColor, west - 1, south); /*   III. Quadrant   */
+            drawPointUnclipped(strokeColor, east + 1, south); /*   IV. Quadrant    */
+            south -= 1;
+        }
     }
 }
 

--- a/runtimes/web/src/framebuffer.ts
+++ b/runtimes/web/src/framebuffer.ts
@@ -193,10 +193,13 @@ export class Framebuffer {
         b1 = 8 * b2;
 
         do {
-            this.drawPointUnclipped(strokeColor, east, north); /*   I. Quadrant     */
-            this.drawPointUnclipped(strokeColor, west, north); /*   II. Quadrant    */
-            this.drawPointUnclipped(strokeColor, west, south); /*   III. Quadrant   */
-            this.drawPointUnclipped(strokeColor, east, south); /*   IV. Quadrant    */
+            if (dc1 !== 0) {
+                this.drawPointUnclipped(strokeColor, east, north); /*   I. Quadrant     */
+                this.drawPointUnclipped(strokeColor, west, north); /*   II. Quadrant    */
+                this.drawPointUnclipped(strokeColor, west, south); /*   III. Quadrant   */
+                this.drawPointUnclipped(strokeColor, east, south); /*   IV. Quadrant    */
+            }
+            
 
             const start = west + 1;
             const len = east - start;
@@ -225,14 +228,16 @@ export class Framebuffer {
             }
         } while (west <= east);
 
-        // Make sure north and south have moved the entire way so top/bottom aren't missing
-        while (north - south < height) {
-            this.drawPointUnclipped(strokeColor, west - 1, north); /*   II. Quadrant    */
-            this.drawPointUnclipped(strokeColor, east + 1, north); /*   I. Quadrant     */
-            north += 1;
-            this.drawPointUnclipped(strokeColor, west - 1, south); /*   III. Quadrant   */
-            this.drawPointUnclipped(strokeColor, east + 1, south); /*   IV. Quadrant    */
-            south -= 1;
+        if (dc1 !== 0) {
+            // Make sure north and south have moved the entire way so top/bottom aren't missing
+            while (north - south < height) {
+                this.drawPointUnclipped(strokeColor, west - 1, north); /*   II. Quadrant    */
+                this.drawPointUnclipped(strokeColor, east + 1, north); /*   I. Quadrant     */
+                north += 1;
+                this.drawPointUnclipped(strokeColor, west - 1, south); /*   III. Quadrant   */
+                this.drawPointUnclipped(strokeColor, east + 1, south); /*   IV. Quadrant    */
+                south -= 1;
+            }
         }
     }
 


### PR DESCRIPTION
Closes #324 

Before: 
<img width="1116" alt="截屏2024-09-14 10 40 19" src="https://github.com/user-attachments/assets/03afca0d-d85f-4529-923d-9aa3f894a991">

After:
<img width="1116" alt="截屏2024-09-14 10 40 48" src="https://github.com/user-attachments/assets/d123303a-1ca6-4953-b93e-dc2dbc20456d">

