### PR TITLE
 web: safely handle immutable globals #779

### DIFF
--- a/runtimes/web/src/netplay/index.ts
+++ b/runtimes/web/src/netplay/index.ts
@@ -252,10 +252,10 @@ export class Netplay {
         const localPeerId = await this.peerMgr.localPeerId;
 
         const loc = window.location;
-        if (loc.protocol == "file:"
+        if (!DEV_NETPLAY && (loc.protocol == "file:"
             || loc.hostname == "localhost"
             || loc.hostname == "127.0.0.1"
-            || loc.hostname == "wasm4.org") {
+            || loc.hostname == "wasm4.org")) {
             return `https://wasm4.org/netplay/#${localPeerId}`;
         }
         const url = new URL(loc.href);

--- a/runtimes/web/src/state.ts
+++ b/runtimes/web/src/state.ts
@@ -38,7 +38,10 @@ export class State {
         for (const exName in runtime.wasm!.exports) {
             const exInst = runtime.wasm!.exports[exName]
             if (exInst instanceof WebAssembly.Global && exName in this.globals) {
-                exInst.value = this.globals[exName];
+                try {
+                    // this will fail for immutable globals that have been exported, but is safe
+                    exInst.value = this.globals[exName];
+                } catch {}
             }
         }
 


### PR DESCRIPTION
See #779

Though this looks a bit ugly, it beats the alternative.

**Explanation:**
JavaScript doesn't support checking directly whether a `Global` object is mutable or not, and parsing enough WASM to determine if each global is mutable [requires being able to parse WASM expressions](https://webassembly.github.io/spec/core/syntax/modules.html#syntax-global), meaning all possible opcodes permitted in initialization and their parameters. I gave it a quick attempt still, but the amount of opcodes that you have support depends on WASM extensions (e.g. globals using reference types and vector types add more opcodes you need to be able to handle in expressions), and simply adding the ones available today doesn't feel future-proof.
I'm also fine with reverting the global patching completely, though it would be a bit unfortunate.
Another alternative is using a proper WASM parsing library, but that increases bundle size instead, and would still need updating if a new WASM extension is ever made.

The `DEV_NETPLAY` addition is for it to use the `http://localhost:3000/?netplay=xyz` URL rather than wasm4.org when enabled, which eliminated some domain issues I was having otherwise. I figured I'll look into that issue in a separate PR.

