### PR TITLE
fix: working tinygo target.json

### DIFF
--- a/cli/assets/templates/go/target.json
+++ b/cli/assets/templates/go/target.json
@@ -1,24 +1,29 @@
 {
-  "llvm-target": "wasm32--wasi",
-  "build-tags": [ "tinygo.wasm" ],
-  "goos": "js",
-  "goarch": "wasm",
-  "linker": "wasm-ld",
-  "libc": "wasi-libc",
-  "cflags": [
-    "--target=wasm32--wasi",
-    "--sysroot={root}/lib/wasi-libc/sysroot",
-    "-Oz"
-  ],
-  "ldflags": [
-    "--allow-undefined",
-    "--no-demangle",
-    "--import-memory",
-    "--initial-memory=65536",
-    "--max-memory=65536",
-    "--stack-first",
-    "-zstack-size=14752",
-    "--strip-all"
-  ],
-  "wasm-abi": "js"
+    "llvm-target": "wasm32-unknown-unknown",
+    "cpu": "generic",
+    "features": "+mutable-globals,+nontrapping-fptoint,+sign-ext,+bulk-memory",
+    "build-tags": [
+        "tinygo.wasm",
+        "wasm_unknown"
+    ],
+    "goos": "linux",
+    "goarch": "arm",
+    "linker": "wasm-ld",
+    "rtlib": "compiler-rt",
+    "scheduler": "none",
+    "cflags": [
+        "-mno-bulk-memory",
+        "-mnontrapping-fptoint",
+        "-msign-ext"
+    ],
+    "ldflags": [
+        "--allow-undefined",
+        "--no-demangle",
+        "--import-memory",
+        "--initial-memory=65536",
+        "--max-memory=65536",
+        "--stack-first",
+        "--no-entry",
+        "-zstack-size=14752"
+    ]
 }


### PR DESCRIPTION
Trying the `hello-world` project, running `make` using Go returns several build errors with the current `target.json` template file.

This PR fixes them by using a working template (should close issue #595).

Currently the errors are: 
```
[wasm-validator error in function 0] unexpected false: Bulk memory operations require bulk memory [--enable-bulk-memory], on
(memory.fill
 (i32.const 14856)
 (i32.const 0)
 (i32.const 905)
)
[wasm-validator error in function 5] unexpected false: Bulk memory operations require bulk memory [--enable-bulk-memory], on
(memory.copy
 (local.get $0)
 (local.get $1)
 (local.get $2)
)
[wasm-validator error in function 6] unexpected false: Bulk memory operations require bulk memory [--enable-bulk-memory], on
(memory.fill
 (local.get $0)
 (local.get $1)
 (local.get $2)
)
[wasm-validator error in function 11] unexpected false: Bulk memory operations require bulk memory [--enable-bulk-memory], on
(memory.copy
 (local.get $0)
 (local.get $1)
 (local.get $2)
)
Fatal: error validating input
wasm-opt failed: exit status 1
```

The `hello-world` project compiles successfully with this patch.

Note: tested with Go 1.23.3 and tinygo 0.34.0 (linux/amd64)