### PR TITLE
fix(site): replicate netlify CI step.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,6 +148,8 @@ jobs:
             - name: Run Netlify CI script
               run: |
                   scripts/run-netlify-ci
+              env:
+                  NODE_OPTIONS: --openssl-legacy-provider
 
     release:
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,6 +136,19 @@ jobs:
                   path: cli-build
                   name: w4
 
+    netlify-ci:
+        name: Run Netlify CI
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  submodules: true
+
+            - name: Run Netlify CI script
+              run: |
+                  scripts/run-netlify-ci
+
     release:
         if: startsWith(github.ref, 'refs/tags/v')
         name: Release


### PR DESCRIPTION
Replicating the Netlify CI build step in the GitHub Action workflow to address https://github.com/aduros/wasm4/issues/810.
This way any site building failures will be visible in future PRs.
Kind of naive approach but does the job:

<img width="1798" alt="image" src="https://github.com/user-attachments/assets/9ea752eb-7252-4be1-a515-4b36f505c144" />

<img width="953" alt="image" src="https://github.com/user-attachments/assets/76d56f39-2469-4466-9cfb-a370ee3c37c9" />
