### PR TITLE
Use gflw as default for the window backend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,11 +43,12 @@ jobs:
               run: |
                   ldd --version
                   sudo apt update
-                  sudo apt install libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev libxkbcommon-dev libasound2-dev libpulse-dev
+                  sudo apt install libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev libxkbcommon-dev libasound2-dev libpulse-dev libwayland-dev
 
             - name: Build
               run: |
-                  cmake -B build -DCMAKE_BUILD_TYPE=Release -DWASM_BACKEND=${{ matrix.wasm_backend }}
+                  cmake -B build -DCMAKE_BUILD_TYPE=Release -DWASM_BACKEND=${{ matrix.wasm_backend }} -DWINDOW_BACKEND=glfw -DGLFW_BUILD_WAYLAND=ON -DGLFW_BUILD_X11=ON
+
                   cmake --build build --config Release --parallel
 
             - name: Install


### PR DESCRIPTION
This pull request defaults the native window backend to GLFW. The current minifb/X11 build, while functional on Wayland via XWayland, has some issues (namely the wayland fractional scale fiasco).

By building with glfw it uses the native wayland API on wayland and the Xorg API on X11. I've tested successfully in the following platforms:

Fedora Rawhide (43 pre-release) [pure wayland]
openSUSE LEAP 15.6 [x11]
Ubuntu 24.10 [wayland + xwayland]