### PR TITLE
Zig template version bump

### DIFF
--- a/cli/assets/templates/zig/build.zig
+++ b/cli/assets/templates/zig/build.zig
@@ -3,12 +3,16 @@ const std = @import("std");
 pub fn build(b: *std.Build) !void {
     const exe = b.addExecutable(.{
         .name = "cart",
-        .root_source_file = b.path("src/main.zig"),
-        .target = b.resolveTargetQuery(.{
-            .cpu_arch = .wasm32,
-            .os_tag = .freestanding,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = b.resolveTargetQuery(.{
+                .cpu_arch = .wasm32,
+                .os_tag = .freestanding,
+            }),
+            .optimize = b.standardOptimizeOption(.{
+                .preferred_optimize_mode = .ReleaseSmall,
+            }),
         }),
-        .optimize = b.standardOptimizeOption(.{}),
     });
 
     exe.entry = .disabled;

--- a/cli/assets/templates/zig/build.zig.zon
+++ b/cli/assets/templates/zig/build.zig.zon
@@ -1,0 +1,14 @@
+.{
+    .name = .cart,
+    .version = "0.0.1",
+    .fingerprint = 0xba388b76e32853e,
+    .minimum_zig_version = "0.15.0-dev.1283+1fcaf90dd",
+    .dependencies = .{},
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "README.md",
+        //"LICENSE",
+    },
+}

--- a/cli/lib/new.js
+++ b/cli/lib/new.js
@@ -82,7 +82,7 @@ const HELP = {
     },
     zig: {
       name: 'Zig',
-      build: 'zig build -Doptimize=ReleaseSmall',
+      build: 'zig build --release=small',
       cart: 'zig-out/bin/cart.wasm',
     }
 };


### PR DESCRIPTION
The [latest zig release is 0.14.1](https://github.com/ziglang/zig/releases), and it had some little breaking changes, this PR fix those.