### PR TITLE
native runtime: fix a NULL dereference

### DIFF
--- a/runtimes/native/src/backend/main.c
+++ b/runtimes/native/src/backend/main.c
@@ -127,10 +127,14 @@ int main (int argc, const char* argv[]) {
 
     if (argc < 2) {
         FILE* file = fopen(argv[0], "rb");
+        if (file == NULL) {
+            goto usage;
+        }
         fseek(file, -sizeof(FileFooter), SEEK_END);
 
         FileFooter footer;
         if (fread(&footer, 1, sizeof(FileFooter), file) < sizeof(FileFooter) || footer.magic != 1414676803) {
+usage:
             // No bundled cart found
             fprintf(stderr, "Usage: wasm4 <cart>\n");
             return 1;


### PR DESCRIPTION
bail out gracefully when we failed to open argv[0]. note that argv[0] is not necessarily an open-able path.