### PR TITLE
Update Rust template to 2024 edition

### DIFF
--- a/cli/assets/templates/rust/Cargo.toml
+++ b/cli/assets/templates/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cart"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/cli/assets/templates/rust/src/alloc.rs
+++ b/cli/assets/templates/rust/src/alloc.rs
@@ -9,8 +9,12 @@ static mut FAST_HEAP: [u8; FAST_HEAP_SIZE] = [0u8; FAST_HEAP_SIZE];
 static mut HEAP: [u8; HEAP_SIZE] = [0u8; HEAP_SIZE];
 
 #[global_allocator]
-static ALLOC: NonThreadsafeAlloc = unsafe {
-    let fast_param = FastAllocParam::new(FAST_HEAP.as_ptr(), FAST_HEAP_SIZE);
-    let buddy_param = BuddyAllocParam::new(HEAP.as_ptr(), HEAP_SIZE, LEAF_SIZE);
+static ALLOC: NonThreadsafeAlloc = {
+    let fast_ptr = &raw mut FAST_HEAP as *const u8;
+    let buddy_ptr = &raw mut HEAP as *const u8;
+
+    let fast_param = FastAllocParam::new(fast_ptr, FAST_HEAP_SIZE);
+    let buddy_param = BuddyAllocParam::new(buddy_ptr, HEAP_SIZE, LEAF_SIZE);
+
     NonThreadsafeAlloc::new(fast_param, buddy_param)
 };

--- a/cli/assets/templates/rust/src/lib.rs
+++ b/cli/assets/templates/rust/src/lib.rs
@@ -15,7 +15,7 @@ const SMILEY: [u8; 8] = [
     0b11000011,
 ];
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 fn update() {
     unsafe { *DRAW_COLORS = 2 }
     text("Hello from Rust!", 10, 10);

--- a/cli/assets/templates/rust/src/wasm4.rs
+++ b/cli/assets/templates/rust/src/wasm4.rs
@@ -55,7 +55,7 @@ pub const SYSTEM_HIDE_GAMEPAD_OVERLAY: u8 = 2;
 pub fn blit(sprite: &[u8], x: i32, y: i32, width: u32, height: u32, flags: u32) {
     unsafe { extern_blit(sprite.as_ptr(), x, y, width, height, flags) }
 }
-extern "C" {
+unsafe extern "C" {
     #[link_name = "blit"]
     fn extern_blit(sprite: *const u8, x: i32, y: i32, width: u32, height: u32, flags: u32);
 }
@@ -87,7 +87,7 @@ pub fn blit_sub(
         )
     }
 }
-extern "C" {
+unsafe extern "C" {
     #[link_name = "blitSub"]
     fn extern_blit_sub(
         sprite: *const u8,
@@ -112,7 +112,7 @@ pub const BLIT_ROTATE: u32 = 8;
 pub fn line(x1: i32, y1: i32, x2: i32, y2: i32) {
     unsafe { extern_line(x1, y1, x2, y2) }
 }
-extern "C" {
+unsafe extern "C" {
     #[link_name = "line"]
     fn extern_line(x1: i32, y1: i32, x2: i32, y2: i32);
 }
@@ -121,7 +121,7 @@ extern "C" {
 pub fn oval(x: i32, y: i32, width: u32, height: u32) {
     unsafe { extern_oval(x, y, width, height) }
 }
-extern "C" {
+unsafe extern "C" {
     #[link_name = "oval"]
     fn extern_oval(x: i32, y: i32, width: u32, height: u32);
 }
@@ -130,7 +130,7 @@ extern "C" {
 pub fn rect(x: i32, y: i32, width: u32, height: u32) {
     unsafe { extern_rect(x, y, width, height) }
 }
-extern "C" {
+unsafe extern "C" {
     #[link_name = "rect"]
     fn extern_rect(x: i32, y: i32, width: u32, height: u32);
 }
@@ -140,7 +140,7 @@ pub fn text<T: AsRef<[u8]>>(text: T, x: i32, y: i32) {
     let text_ref = text.as_ref();
     unsafe { extern_text(text_ref.as_ptr(), text_ref.len(), x, y) }
 }
-extern "C" {
+unsafe extern "C" {
     #[link_name = "textUtf8"]
     fn extern_text(text: *const u8, length: usize, x: i32, y: i32);
 }
@@ -152,7 +152,7 @@ pub fn vline(x: i32, y: i32, len: u32) {
     }
 }
 
-extern "C" {
+unsafe extern "C" {
     #[link_name = "vline"]
     fn extern_vline(x: i32, y: i32, len: u32);
 }
@@ -164,7 +164,7 @@ pub fn hline(x: i32, y: i32, len: u32) {
     }
 }
 
-extern "C" {
+unsafe extern "C" {
     #[link_name = "hline"]
     fn extern_hline(x: i32, y: i32, len: u32);
 }
@@ -179,7 +179,7 @@ extern "C" {
 pub fn tone(frequency: u32, duration: u32, volume: u32, flags: u32) {
     unsafe { extern_tone(frequency, duration, volume, flags) }
 }
-extern "C" {
+unsafe extern "C" {
     #[link_name = "tone"]
     fn extern_tone(frequency: u32, duration: u32, volume: u32, flags: u32);
 }
@@ -202,7 +202,7 @@ pub const TONE_NOTE_MODE: u32 = 64;
 // │                                                                           │
 // └───────────────────────────────────────────────────────────────────────────┘
 
-extern "C" {
+unsafe extern "C" {
     /// Reads up to `size` bytes from persistent storage into the pointer `dest`.
     pub fn diskr(dest: *mut u8, size: u32) -> u32;
 
@@ -221,7 +221,7 @@ pub fn trace<T: AsRef<str>>(text: T) {
     let text_ref = text.as_ref();
     unsafe { extern_trace(text_ref.as_ptr(), text_ref.len()) }
 }
-extern "C" {
+unsafe extern "C" {
     #[link_name = "traceUtf8"]
     fn extern_trace(trace: *const u8, length: usize);
 }


### PR DESCRIPTION
This PR updates the Rust template to the 2024 edition.

## changes
### add explicit unsafe
Some things (that technically always were "unsafe" are now required to be explicitly marked `unsafe` (like `no_mangle` attribute and `extern "C"` functions).

### remove shared ref to static mut
In `alloc.rs` the old code ran into the [Disallow references to static mut](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html) lint (`deny` since 2024 edition) because `.as_ptr()` implicitly took a shared reference to the static mut u8 array. I'm not an unsafe expert but I guess the old use was fine, but there is actually a way to get that pointer without unsafe, by using `&raw` and pointer casting - which is all fine in safe rust because we never turn it into a reference or read from it.

## testing
I'm pretty new to wasm4 (just found it and I think it's awesome) so I just ran `w4 watch` on the new template and that still worked as expected.

### Update 1
Originally I also updates `buddy-alloc` to `0.6.0` but it looks like this causes some memory issues. I have no idea what's to blame. If some unsafe code in Rust is wrong, or something inside buddy-alloc or in the `extern "C"` functions but reverting back to 0.4.1 seems to have fixed the issue.