### PR TITLE
Add a run-web step to the Zig build file

### DIFF
--- a/cli/assets/templates/zig/build.zig
+++ b/cli/assets/templates/zig/build.zig
@@ -30,7 +30,7 @@ pub fn build(b: *std.Build) !void {
     const step_run = b.step("run", "compile and run the cart");
     step_run.dependOn(&run_exe.step);
 
-    const run_exe_web = b.addSystemCommand(&.{ "w4", "run "});
+    const run_exe_web = b.addSystemCommand(&.{ "w4", "run"});
     run_exe_web.addArtifactArg(exe);
 
     const step_run_web = b.step("run-web", "compile and run the cart in a web browser");


### PR DESCRIPTION
This PR adds a build step to the Zig template to run the cart in a web browser.