### PR TITLE
bump toywasm to v76

### DIFF
--- a/runtimes/native/CMakeLists.txt
+++ b/runtimes/native/CMakeLists.txt
@@ -70,6 +70,7 @@ ExternalProject_Add(toywasm
     SOURCE_DIR "${CMAKE_SOURCE_DIR}/vendor/toywasm"
     CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${toywasm_tmp_install}
+        -DUSE_DEFAULT_TOOLCHAIN=ON
         -DBUILD_TESTING=OFF
         -DTOYWASM_BUILD_CLI=OFF
         -DTOYWASM_BUILD_UNITTEST=OFF


### PR DESCRIPTION
i guess most of changes are not important for wasm4.
the only relevant change i remember is the text size reduction.
this version bump reduced the wasm4 binary size a bit.
(619016 -> 576872 bytes, macOS, amd64, clang)