### PR TITLE
Make indexes/indices consistent

### DIFF
--- a/cli/assets/templates/grain/bindings/index.md
+++ b/cli/assets/templates/grain/bindings/index.md
@@ -242,9 +242,9 @@ Wasm4.mouseButtons() & Wasm4._MOUSE_LEFT
 drawColors : (colors: Uint16) => Void
 ```
 
-Set the draw colors. The draw colors are a set of 4 indexes into the palette. Drawing functions use these indexes to decide which colors to use, and what to use them for.
+Set the draw colors. The draw colors are a set of 4 indices into the palette. Drawing functions use these indices to decide which colors to use, and what to use them for.
 
-It's a 16 bit value that holds 4 indexes. Bits 0-3 (the least significant bits) hold the first draw color, bits 4-7 hold the second draw color, and so on.
+It's a 16 bit value that holds 4 indices. Bits 0-3 (the least significant bits) hold the first draw color, bits 4-7 hold the second draw color, and so on.
 
 Setting a draw color to 1 means use the palette color 1 for that draw color. The same applies when setting a draw color to 2, 3, or 4.
 

--- a/cli/assets/templates/grain/bindings/wasm4.gr
+++ b/cli/assets/templates/grain/bindings/wasm4.gr
@@ -130,9 +130,9 @@ provide let mouseButtons = () => {
 }
 
 /**
- * Set the draw colors. The draw colors are a set of 4 indexes into the palette. Drawing functions use these indexes to decide which colors to use, and what to use them for.
+ * Set the draw colors. The draw colors are a set of 4 indices into the palette. Drawing functions use these indices to decide which colors to use, and what to use them for.
  *
- * It's a 16 bit value that holds 4 indexes. Bits 0-3 (the least significant bits) hold the first draw color, bits 4-7 hold the second draw color, and so on.
+ * It's a 16 bit value that holds 4 indices. Bits 0-3 (the least significant bits) hold the first draw color, bits 4-7 hold the second draw color, and so on.
  *
  * Setting a draw color to 1 means use the palette color 1 for that draw color. The same applies when setting a draw color to 2, 3, or 4.
  *

--- a/site/docs/guides/basic-drawing.md
+++ b/site/docs/guides/basic-drawing.md
@@ -133,10 +133,10 @@ The first color in the palette register is used as the screen background color.
 
 ## The `DRAW_COLORS` Register
 
-`DRAW_COLORS` is a set of 4 indexes into `PALETTE`. Drawing functions use these indexes to
+`DRAW_COLORS` is a set of 4 indices into `PALETTE`. Drawing functions use these indices to
 decide which colors to use, and what to use them for.
 
-`DRAW_COLORS` is a 16 bit value that holds 4 indexes. Bits 0-3 (the least significant bits)
+`DRAW_COLORS` is a 16 bit value that holds 4 indices. Bits 0-3 (the least significant bits)
 hold the first draw color, bits 4-7 hold the second draw color, and so on.
 
 Setting a draw color to `1` means use `PALETTE` color 1 for that draw color. The same applies

--- a/site/docs/tutorials/iwas/the-iwas-file-format.md
+++ b/site/docs/tutorials/iwas/the-iwas-file-format.md
@@ -404,8 +404,8 @@ Each note is a **signed 8-bit** value, and it will range from **-96 to 96**, or 
 - If **lower than zero**, then it will play a tone using the **shadow channel**.
 - If **equals zero**, it will **do nothing**.
 
-Each index corresponds to a frequency stored in the note lookup table. Negative and positive indexes should all point to the same frequency.
-For instance: indexes `-1` and `1` would both point to note index `1` (16Hz).
+Each index corresponds to a frequency stored in the note lookup table. Negative and positive indices should all point to the same frequency.
+For instance: indices `-1` and `1` would both point to note index `1` (16Hz).
 
 ## Note breaks
 


### PR DESCRIPTION
I noticed a handful of places in your docs that referred to "indexes" rather than "indices" (where in another handful of places, it was correct).
I've made this consistent, outside of libretro.h from RetroArch.