### PR TITLE
libretro: When reseting, clean up the entire wasm instance

### DIFF
--- a/runtimes/native/src/backend/main_libretro.c
+++ b/runtimes/native/src/backend/main_libretro.c
@@ -349,6 +349,12 @@ void retro_unload_game () {
 }
 
 void retro_reset () {
+    // Complete clear all memory and build a new instance as reusing
+    // the existing model could result in a memory leak.
+    w4_wasmDestroy();
+
+    // Build a new wasm instance.
+    memory = w4_wasmInit();
     w4_runtimeInit(memory, &disk);
     w4_wasmLoadModule(wasmData, wasmLength);
 }


### PR DESCRIPTION
Found a small potential issue with reseting the libretro core. Since it doesn't clear out the instance, running runtimeInit() would overwrite it.
