### PR TITLE
fix SIGSEGV on null pointer dereference

### DIFF
--- a/runtimes/native/src/backend/wasm_wasm3.c
+++ b/runtimes/native/src/backend/wasm_wasm3.c
@@ -179,6 +179,7 @@ uint8_t* w4_wasmInit () {
     runtime = m3_NewRuntime(env, wasm3StackSize, NULL);
 
     runtime->memory.maxPages = 1;
+    runtime->memory.pageSize = wasm3StackSize;
     ResizeMemory(runtime, 1);
 
     return m3_GetMemory(runtime, NULL, 0);


### PR DESCRIPTION
wasm3 implemented [custom page size](https://github.com/wasm3/wasm3/pull/496) support in 2024 and no longer hardcodes 65536 bytes. However, because the page size is not being set, it remains `0`, which eventually leads to a null pointer dereference at this line.

https://github.com/aduros/wasm4/blob/71f4b34401168072f34b8a7e4b19751ed13632ed/runtimes/native/src/runtime.c#L96

This fixes #876 