### PR TITLE
Fix #880 Rust template code link errors

### DIFF
--- a/cli/assets/templates/rust/src/wasm4.rs
+++ b/cli/assets/templates/rust/src/wasm4.rs
@@ -154,13 +154,14 @@ pub const TONE_NOTE_MODE: u32 = 64;
 // │                                                                           │
 // └───────────────────────────────────────────────────────────────────────────┘
 
-#[link(wasm_import_module = "env")]
-unsafe extern "C" {
-    /// Reads up to `size` bytes from persistent storage into the pointer `dest`.
-    pub fn diskr(dest: *mut u8, size: u32) -> u32;
+/// Reads up to `size` bytes from persistent storage into the pointer `dest`.
+pub fn diskr(dest: &mut [u8]) -> u32 {
+    unsafe { extern_diskr(dest.as_mut_ptr(), dest.len()) }
+}
 
-    /// Writes up to `size` bytes from the pointer `src` into persistent storage.
-    pub fn diskw(src: *const u8, size: u32) -> u32;
+/// Writes up to `size` bytes from the pointer `src` into persistent storage.
+pub fn diskw(src: &[u8]) -> u32 {
+    unsafe { extern_diskw(src.as_ptr(), src.len()) }
 }
 
 // ┌───────────────────────────────────────────────────────────────────────────┐
@@ -218,4 +219,10 @@ unsafe extern "C" {
 
     #[link_name = "traceUtf8"]
     fn extern_trace(trace: *const u8, length: usize);
+
+    #[link_name = "diskr"]
+    fn extern_diskr(dest: *mut u8, size: usize) -> u32;
+
+    #[link_name = "diskw"]
+    fn extern_diskw(src: *const u8, size: usize) -> u32;
 }

--- a/cli/assets/templates/rust/src/wasm4.rs
+++ b/cli/assets/templates/rust/src/wasm4.rs
@@ -55,10 +55,6 @@ pub const SYSTEM_HIDE_GAMEPAD_OVERLAY: u8 = 2;
 pub fn blit(sprite: &[u8], x: i32, y: i32, width: u32, height: u32, flags: u32) {
     unsafe { extern_blit(sprite.as_ptr(), x, y, width, height, flags) }
 }
-unsafe extern "C" {
-    #[link_name = "blit"]
-    fn extern_blit(sprite: *const u8, x: i32, y: i32, width: u32, height: u32, flags: u32);
-}
 
 /// Copies a subregion within a larger sprite atlas to the framebuffer.
 #[allow(clippy::too_many_arguments)]
@@ -87,20 +83,6 @@ pub fn blit_sub(
         )
     }
 }
-unsafe extern "C" {
-    #[link_name = "blitSub"]
-    fn extern_blit_sub(
-        sprite: *const u8,
-        x: i32,
-        y: i32,
-        width: u32,
-        height: u32,
-        src_x: u32,
-        src_y: u32,
-        stride: u32,
-        flags: u32,
-    );
-}
 
 pub const BLIT_2BPP: u32 = 1;
 pub const BLIT_1BPP: u32 = 0;
@@ -112,37 +94,21 @@ pub const BLIT_ROTATE: u32 = 8;
 pub fn line(x1: i32, y1: i32, x2: i32, y2: i32) {
     unsafe { extern_line(x1, y1, x2, y2) }
 }
-unsafe extern "C" {
-    #[link_name = "line"]
-    fn extern_line(x1: i32, y1: i32, x2: i32, y2: i32);
-}
 
 /// Draws an oval (or circle).
 pub fn oval(x: i32, y: i32, width: u32, height: u32) {
     unsafe { extern_oval(x, y, width, height) }
-}
-unsafe extern "C" {
-    #[link_name = "oval"]
-    fn extern_oval(x: i32, y: i32, width: u32, height: u32);
 }
 
 /// Draws a rectangle.
 pub fn rect(x: i32, y: i32, width: u32, height: u32) {
     unsafe { extern_rect(x, y, width, height) }
 }
-unsafe extern "C" {
-    #[link_name = "rect"]
-    fn extern_rect(x: i32, y: i32, width: u32, height: u32);
-}
 
 /// Draws text using the built-in system font.
 pub fn text<T: AsRef<[u8]>>(text: T, x: i32, y: i32) {
     let text_ref = text.as_ref();
     unsafe { extern_text(text_ref.as_ptr(), text_ref.len(), x, y) }
-}
-unsafe extern "C" {
-    #[link_name = "textUtf8"]
-    fn extern_text(text: *const u8, length: usize, x: i32, y: i32);
 }
 
 /// Draws a vertical line
@@ -152,21 +118,11 @@ pub fn vline(x: i32, y: i32, len: u32) {
     }
 }
 
-unsafe extern "C" {
-    #[link_name = "vline"]
-    fn extern_vline(x: i32, y: i32, len: u32);
-}
-
 /// Draws a horizontal line
 pub fn hline(x: i32, y: i32, len: u32) {
     unsafe {
         extern_hline(x, y, len);
     }
-}
-
-unsafe extern "C" {
-    #[link_name = "hline"]
-    fn extern_hline(x: i32, y: i32, len: u32);
 }
 
 // ┌───────────────────────────────────────────────────────────────────────────┐
@@ -178,10 +134,6 @@ unsafe extern "C" {
 /// Plays a sound tone.
 pub fn tone(frequency: u32, duration: u32, volume: u32, flags: u32) {
     unsafe { extern_tone(frequency, duration, volume, flags) }
-}
-unsafe extern "C" {
-    #[link_name = "tone"]
-    fn extern_tone(frequency: u32, duration: u32, volume: u32, flags: u32);
 }
 
 pub const TONE_PULSE1: u32 = 0;
@@ -202,6 +154,7 @@ pub const TONE_NOTE_MODE: u32 = 64;
 // │                                                                           │
 // └───────────────────────────────────────────────────────────────────────────┘
 
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     /// Reads up to `size` bytes from persistent storage into the pointer `dest`.
     pub fn diskr(dest: *mut u8, size: u32) -> u32;
@@ -221,7 +174,48 @@ pub fn trace<T: AsRef<str>>(text: T) {
     let text_ref = text.as_ref();
     unsafe { extern_trace(text_ref.as_ptr(), text_ref.len()) }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
+    #[link_name = "blit"]
+    fn extern_blit(sprite: *const u8, x: i32, y: i32, width: u32, height: u32, flags: u32);
+
+    #[link_name = "blitSub"]
+    fn extern_blit_sub(
+        sprite: *const u8,
+        x: i32,
+        y: i32,
+        width: u32,
+        height: u32,
+        src_x: u32,
+        src_y: u32,
+        stride: u32,
+        flags: u32,
+    );
+
+    #[link_name = "line"]
+    fn extern_line(x1: i32, y1: i32, x2: i32, y2: i32);
+
+    #[link_name = "oval"]
+    fn extern_oval(x: i32, y: i32, width: u32, height: u32);
+
+    #[link_name = "rect"]
+    fn extern_rect(x: i32, y: i32, width: u32, height: u32);
+
+    #[link_name = "textUtf8"]
+    fn extern_text(text: *const u8, length: usize, x: i32, y: i32);
+
+    #[link_name = "vline"]
+    fn extern_vline(x: i32, y: i32, len: u32);
+
+    #[link_name = "hline"]
+    fn extern_hline(x: i32, y: i32, len: u32);
+
+    #[link_name = "tone"]
+    fn extern_tone(frequency: u32, duration: u32, volume: u32, flags: u32);
+
     #[link_name = "traceUtf8"]
     fn extern_trace(trace: *const u8, length: usize);
 }

--- a/site/docs/guides/saving-data.md
+++ b/site/docs/guides/saving-data.md
@@ -99,11 +99,7 @@ diskw(&game_data transmute &u8, sizeof$i32());
 
 ```rust
 let game_data: i32 = 1337;
-
-unsafe {
-    let game_data_bytes = game_data.to_le_bytes();
-    diskw(game_data_bytes.as_ptr(), core::mem::size_of::<i32>() as u32);
-}
+diskw(&game_data.to_le_bytes());
 ```
 
 ```wasm
@@ -197,10 +193,10 @@ diskr(&game_data transmute &u8, sizeof$i32());
 ```
 
 ```rust
-let game_data = unsafe {
+let game_data = {
     let mut buffer = [0u8; core::mem::size_of::<i32>()];
 
-    diskr(buffer.as_mut_ptr(), buffer.len() as u32);
+    diskr(&mut buffer);
 
     i32::from_le_bytes(buffer)
 };


### PR DESCRIPTION
Fixes #880 by adding `#[link(wasm_import_module = "env")]` to the externs.

Also included: make it possible to call diskr() and diskw() from safe code.