### PR TITLE
ci: add a webOS build for the libretro core

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,6 +101,10 @@ include:
     file: '/tvos-cmake.yml'
 
   ################################## MISC ####################################
+  # webOS (LGTV)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/webos-cmake.yml'
+
   # Emscripten
   - project: 'libretro-infrastructure/ci-templates'
     file: '/emscripten-static-cmake.yml' 
@@ -295,6 +299,12 @@ libretro-build-wiiu:
     - .core-defs
 
 ################################### MISC #####################################
+
+# webOS 32-bit (LGTV)
+libretro-build-webos-armv7a:
+  extends:
+    - .libretro-webos-armv7a-cmake
+    - .core-defs
 
 # Emscripten
 libretro-build-emscripten:


### PR DESCRIPTION
The libretro CI here covers desktops, Android, iOS/tvOS, six consoles and Emscripten, but not webOS — LG TVs run RetroArch too, and the core needs nothing special to get there.

The `webos-cmake` template is used as-is: `.core-defs` already points `CMAKE_SOURCE_ROOT` at `runtimes/native` and passes `-DLIBRETRO=ON`, which is all the job needs.

Verified by replaying it against the same buildroot SDK the build image bakes in: it produces `wasm4_libretro.so`, `ELF 32-bit LSB shared object, ARM, EABI5`.